### PR TITLE
Add dice rolling skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -298,3 +298,6 @@
 [submodule "twitter-skill"]
 	path = twitter-skill
 	url = https://github.com/btotharye/mycroft-twitter-skill.git
+[submodule "skill-dice"]
+	path = skill-dice
+	url = https://github.com/Friday811/skill-dice

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ For an example pull request , check out [this PR](https://github.com/MycroftAI/m
 | :question:          | [daily-meditation](../../wiki/SKILL-daily-meditation)          |Plays your Daily Meditation from the  Meditation Podcast     |
 | :construction:      | [deepdream_skill](../../wiki/SKILL-deepdream)                  | Adds Deepdreaming image converstion to Mycroft       |
 | :question:          | [diagnostics](../../wiki/SKILL-diagnostics)                    | Diagnostic tools (CPU %age, free space, etc)    |
+| :construction:      | [dice-roll](../../wiki/DKILL-dice)                             | Rolls dice spoken in RPG notation.                                                       |
 | :question:          | [domoticz_skill](../../wiki/SKILL-domoticz)                    | Skill integrating Mycroft with Domoticz    |
 | :question:          | [drive_servos](../../wiki/SKILL-drive-servos)                  | Control Hacked-Servo-Engines to make your mycroft move around   |
 | :question:          | [earth-orbit-pic-skill](../../wiki/SKILL-earth-orbit-pic)      | Earth orbit picture skill   |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For an example pull request , check out [this PR](https://github.com/MycroftAI/m
 | :question:          | [daily-meditation](../../wiki/SKILL-daily-meditation)          |Plays your Daily Meditation from the  Meditation Podcast     |
 | :construction:      | [deepdream_skill](../../wiki/SKILL-deepdream)                  | Adds Deepdreaming image converstion to Mycroft       |
 | :question:          | [diagnostics](../../wiki/SKILL-diagnostics)                    | Diagnostic tools (CPU %age, free space, etc)    |
-| :construction:      | [dice-roll](../../wiki/DKILL-dice)                             | Rolls dice spoken in RPG notation.                                                       |
+| :construction:      | [dice-roll](../../wiki/SKILL-dice)                             | Rolls dice spoken in RPG notation.                                                       |
 | :question:          | [domoticz_skill](../../wiki/SKILL-domoticz)                    | Skill integrating Mycroft with Domoticz    |
 | :question:          | [drive_servos](../../wiki/SKILL-drive-servos)                  | Control Hacked-Servo-Engines to make your mycroft move around   |
 | :question:          | [earth-orbit-pic-skill](../../wiki/SKILL-earth-orbit-pic)      | Earth orbit picture skill   |


### PR DESCRIPTION
Repo URL: https://github.com/Friday811/skill-dice
Name: skill-dice
Description: Rolls dice in RPG notation (ex: "_wake word_ roll 3d5").
Status: Under construction. 