### PR TITLE
Add new wolfram alpha fallback skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -361,3 +361,6 @@
 [submodule "openhab-skill"]
 	path = openhab-skill
 	url = https://github.com/mortommy/skill-openhab
+[submodule "fallback-wolfram-alpha"]
+	path = fallback-wolfram-alpha
+	url = https://github.com/mycroftai/fallback-wolfram-alpha.git


### PR DESCRIPTION
Add the wolfram-alpha skill for the fallback system so it can be installed by msm.