### PR TITLE
Add brain-skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -367,3 +367,6 @@
 [submodule "fallback-aiml"]
 	path = fallback-aiml
 	url = https://github.com/forslund/fallback-aiml.git
+[submodule "brain-skill"]
+	path = brain-skill
+	url = https://github.com/skeledrew/brain-skill.git

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ For an example pull request , check out [this PR](https://github.com/MycroftAI/m
 | :question:          |[bioinformatics](../../wiki/SKILL-bioinformatics)               | Adds Bio-Linux Commands to Mycroft   |  
 | :question:          | [bitcoin](../../wiki/SKILL-bitcoin)                            | Check the price of bitcoin                                                               |  
 | :construction:      | [bitcoin-price](../../wiki/SKILL-bitcoin-price)                |  Checks the price of bitcoin                             |
+| :construction:          | [brain-skill](../../wiki/SKILL-brain)                |  Chain intents and provide some services                             |
 | :question:          | [cbc-news-skill](../../wiki/SKILL-cbc-news)        | Fetches CBC News Podcast             |  
 | :question:          | [clarifai-image-recognition-skill](../../wiki/SKILL-clarifai-image-recognition)      | Image recognition skill based on clarifai   |
 | :question:          | [clementine-player-skill](../../wiki/SKILL-clementine-player)  | Controls your clementine-player localy. A fork from amarok-player.   |


### PR DESCRIPTION
Still under construction, but most of the main infrastructure has been tested. This skill is intended to facilitate easy communication between and chaining of any skill's intents, and also expose various basic services.
https://github.com/skeledrew/brain-skill