### PR TITLE
Repository updated to openHAB official repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -357,7 +357,7 @@
 	url = https://github.com/eClarity/skill-autogui.git
 [submodule "openhab-skill"]
 	path = openhab-skill
-	url = https://github.com/mortommy/skill-openhab
+	url = https://github.com/openhab/openhab-mycroft.git
 [submodule "fallback-wolfram-alpha"]
 	path = fallback-wolfram-alpha
 	url = https://github.com/mycroftai/fallback-wolfram-alpha.git

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ For an example pull request , check out [this PR](https://github.com/MycroftAI/m
 | :question:          | [nasa-picture-of-the-day](../../wiki/SKILL-nasa-pic-of-the-day)                    | Nasa picture of the day from the NASA API |
 | :question:          | [near-earth-orbit-skill](../../wiki/SKILL-near-earth-orbit)                    | Near Earth orbit alert skill via the NASA API   |
 | :construction:	      | [objective-skill](../../wiki/SKILL-objective)                  | skills can now register objectives almost the same has an intent would be registered with ObjectiveBuilder class              |
-| :construction:	  |	[openhab-skill](../../wiki/SKILL-Openhab)					| This skill adds Openhab support to Mycroft |
+| :question:	  |	[openhab-skill](../../wiki/SKILL-openHAB)					| This skill adds openHAB support to Mycroft |
 | :question:          | [pandora-skill](../../wiki/SKILL-pandora)                   | Adds Pandora to mycroft via Pianobar  |
 | :question:          | [photolocation-skill](../../wiki/SKILL-photolocation)          | Searches wikimedia for photos of location  |
 | :question:          | [pickup-line-skill](../../wiki/SKILL-pickup-line)  | Responds with random nerdy pick-up lines          |


### PR DESCRIPTION
The project has moved to the openHAB official repo. 
Updated the url and also some openHAB references according to the naming convention.

Thank you.