### PR TITLE
fixing url for skill-radio-rne

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -339,7 +339,7 @@
 	url = https://github.com/ChristopherRogers1991/mycroft-speedtest.git
 [submodule "skill-radio-rne"]
 	path = skill-radio-rne
-	url = git@github.com:ChrisFernandez/skill-radio-rne.git
+	url = https://github.com/ChrisFernandez/skill-radio-rne
 [submodule "unsplash-wallpaper-plasma-skill"]
 	path = unsplash-wallpaper-plasma-skill
 	url = https://github.com/AIIX/unsplash-wallpaper-plasma-skill


### PR DESCRIPTION
testing travis to ensure build passes and it can properly clone into repo.  It had the wrong URL path was using git@ instead of https link.