### PR TITLE
Add duckduckgo skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -379,3 +379,6 @@
 [submodule "easter-eggs"]
 	path = easter-eggs
 	url = https://github.com/JarbasAI/skill_easter_eggs.git
+[submodule "duckduckgo-skill"]
+	path = duckduckgo-skill
+	url = https://github.com/MycroftAI/fallback-duckduckgo.git

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A repository for sharing and collaboration for third-party Mycroft skills develo
 |[Configuration](https://github.com/mycroftai/skill-configuration#readme)|       Update Mycroft configuration<br>```"configuration update"```  |
 |[Date Time](https://github.com/MycroftAI/skill-date-time#readme)     |          Tell the date or time<br> ```"what time is it"```             |
 |[Desktop Launcher](https://github.com/MycroftAI/skill-desktop-launcher#readme)| Open Applications on Desktop<br>```"open firefox"```          |
+|[DuckDuckGo](https://github.com/MycroftAI/fallback-duckduckgo)       | Query DuckDuckGo for general questions<br> ```what is frankenstein```  |
 |[Hello World](https://github.com/mycroftai/skill-hello-world#readme) | Hello world and Mycroft manners<br> ```"how are you"```                |
 |[IP](https://github.com/MycroftAI/skill-ip#readme)                   | Check the device's IP Address<br> ```"what is your ip address"```      |
 |[Joke](https://github.com/MycroftAI/skill-joke#readme)               | Tell jokes<br> ```"tell me a joke"```                                  |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A repository for sharing and collaboration for third-party Mycroft skills develo
 |[Configuration](https://github.com/mycroftai/skill-configuration#readme)|       Update Mycroft configuration<br>```"configuration update"```  |
 |[Date Time](https://github.com/MycroftAI/skill-date-time#readme)     |          Tell the date or time<br> ```"what time is it"```             |
 |[Desktop Launcher](https://github.com/MycroftAI/skill-desktop-launcher#readme)| Open Applications on Desktop<br>```"open firefox"```          |
-|[DuckDuckGo](https://github.com/MycroftAI/fallback-duckduckgo)       | Query DuckDuckGo for general questions<br> ```what is frankenstein```  |
+|[DuckDuckGo](https://github.com/MycroftAI/fallback-duckduckgo#readme)       | Query DuckDuckGo for general questions<br> ```what is frankenstein```  |
 |[Hello World](https://github.com/mycroftai/skill-hello-world#readme) | Hello world and Mycroft manners<br> ```"how are you"```                |
 |[IP](https://github.com/MycroftAI/skill-ip#readme)                   | Check the device's IP Address<br> ```"what is your ip address"```      |
 |[Joke](https://github.com/MycroftAI/skill-joke#readme)               | Tell jokes<br> ```"tell me a joke"```                                  |


### PR DESCRIPTION
## Description:

Query DuckDuckGo as a fallback when no other skill can answer the question.
We are planning on adding this as a default skill.

## Checklist:
  - [x] Used [Meta Editor](http://rawgit.com/MycroftAI/mycroft-skills/master/meta_editor.html) to generate the skill README
  - [x] Skill has been tested and works
 - [x] README.md has been updated with your skill phrase and description
