### PR TITLE
Add skill-SST-control to switch between local and internet SST

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -403,3 +403,6 @@
 [submodule "skill-australian-news"]
 	path = skill-australian-news
 	url = https://github.com/KathyReid/skill-australian-news
+[submodule "skill-SST-control"]
+	path = skill-SST-control
+	url = https://github.com/NeonGeckoCom/skill-STT-control.git

--- a/README.md
+++ b/README.md
@@ -232,3 +232,4 @@ For an example pull request , check out [this PR](https://github.com/MycroftAI/m
 | :question:  | [release-test](../../wiki/SKILL-release-test)                            | test mycroft release                                                        |  
 | :heavy_check_mark:  | [skill-caffeinewiz](https://github.com/reginaneon/skill-caffeinewiz.git)| Provides the caffeine content of various drinks on request.<br>```what's caffeine content of *drink*?``` 
 | :heavy_check_mark:  | [mycroft-timer](https://github.com/MycroftAI/mycroft-timer.git)| Set a timer on your device<br>```set a timer for 30 minutes``` 
+| :heavy_check_mark:  | [STT-control](https://github.com/NeonGeckoCom/skill-STT-control.git)| Switch between local/internet STT. Note: depends on local pocketsphinx STT PR<br>```Start local speech.```


### PR DESCRIPTION
## skill-SST-control
The skill-SST-control allows switching the SST process between local and internet processing.

## Description
This skill adds/removes signal files to indicate which SST process to use and then restarts the speech/voice client. This includes the skip-wake-words PR which also includes the new restart() function in speech/listener.py.  And this skill is dependent on the PR Feature/local pocketsphinx STT #1225.


## Examples
* "Start internet speech"
* "Begin local processing"
* "Use local speech"
There is a confirmation step in this skill.

## Credits
NeonGeckoInc

## Checklist:
  - [ ] Used [Meta Editor](http://rawgit.com/MycroftAI/mycroft-skills/master/meta_editor.html) to generate the skill README
  - [ x] Skill has been tested and works
  - [ x] .gitmodules has been updated with the following:

 [submodule "skill-SST-control"]
	path = skill-SST-control
	url = https://github.com/NeonGeckoCom/skill-STT-control.git

 - [ x] README.md has been updated with your skill phrase and description
