### PR TITLE
KC Streetcar Skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -405,4 +405,4 @@
 	url = https://github.com/aussieW/skill-confucius-say.git
 [submodule "nerdery-kc-streetcar"]
 	path = nerdery-kc-streetcar
-	url = https://github.com/bw3740/mycroft-skills
+	url = https://github.com/bw3740/nerdery-kc-streetcar

--- a/.gitmodules
+++ b/.gitmodules
@@ -403,3 +403,6 @@
 [submodule "skill-confucius-say"]
 	path = skill-confucius-say
 	url = https://github.com/aussieW/skill-confucius-say.git
+[submodule "nerdery-kc-streetcar"]
+	path = nerdery-kc-streetcar
+	url = https://github.com/bw3740/mycroft-skills

--- a/README.md
+++ b/README.md
@@ -227,3 +227,4 @@ wiki pages.  Also please include the phrase to trigger on as well for your skill
 | :skull:             | [Enhanced Bitcoin](https://github.com/chrison999/mycroft-skill-bitcoin-enhanced#mycroft-skill-bitcoin-enhanced)    | Enhanced bitcoin from api.bitcoinaverage.com        |
 | :heavy_check_mark:   | [Farting](https://github.com/aussieW/skill-farting)                      | Fart on request or randomly    |
 | :heavy_check_mark:   | [Confucius Say](https://github.com/aussieW/skill-confucius-say)   | Get quotes from Confucius, including humorous quotes.       |
+| :construction:       | [Kansas City Streetcar](https://github.com/bw3740/nerdery-kc-streetcar)   | Get next time streetcar will arrive at specific stop and direction.       |


### PR DESCRIPTION
## Description:
Retrieves estimates for next Kansas City streetcar arrival times in both directions.

**Short description of your skill and what it does
Based on a configurable static stop, this skill retrieves the number of minutes until the next streetcars arrive in either the North or South directions. 

Information is provided free-of-charge from http://www.kc-metro.com/tmwebwatch/LiveArrivalTimes. This page makes to POST calls to http://www.kc-metro.com/tmwebwatch/Arrivals.aspx/getStops to get a list of stops and http://www.kc-metro.com/tmwebwatch/Arrivals.aspx/getStopTimes to get the arrival times for a specific stop.

This skill is still in it's early stages of development. It is hard-coded to Southbound 7th & Main St until settings can be implemented.

## Checklist:
  - [X] Used [Meta Editor](http://rawgit.com/MycroftAI/mycroft-skills/master/meta_editor.html) to generate the skill README
  - [ ] Skill has been tested and works
  - [X] README.md has been updated with the following:
  ```
  +[submodule "nerdery-kc-streetcar"]
  +	path = nerdery-kc-streetcar
  +	url = https://github.com/bw3740/nerdery-kc-streetcar.git
 ```
 - [X] README.md has been updated with your skill phrase and description
