### PR TITLE
CaffeineWiz Skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -112,9 +112,6 @@
 [submodule "translate-skill"]
 	path = translate-skill
 	url = https://github.com/jcasoft/translate-skill
-[submodule "AVmusic"]
- 	path = AVmusic
-	url = https://github.com/reginaneon/AVmusic.git
 [submodule "CaffeineWiz"]
  	path = CaffeineWiz
 	url = https://github.com/reginaneon/CaffeineWiz.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -103,3 +103,9 @@
 [submodule "translate-skill"]
 	path = translate-skill
 	url = https://github.com/jcasoft/translate-skill
+[submodule "AVmusic"]
+ 	path = AVmusic
+	url = https://github.com/reginaneon/AVmusic.git
+[submodule "CaffeineWiz"]
+ 	path = CaffeineWiz
+	url = https://github.com/reginaneon/CaffeineWiz.git

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 The official home of skills for the Mycroft ecosystem.  These skills are written by both the MycroftAI team and others within the Community.
 **[HTML version of this document](https://mycroftai.github.io/mycroft-skills)**
- 
+
 ## Available Skills
 
 |      Skill Name                                                               |                Description<br>"handled phrases"                      |                                           

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 The official home of skills for the Mycroft ecosystem.  These skills are written by both the MycroftAI team and others within the Community.
 **[HTML version of this document](https://mycroftai.github.io/mycroft-skills)**
-
+ 
 ## Available Skills
 
 |      Skill Name                                                               |                Description<br>"handled phrases"                      |                                           

--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ wiki pages.  Also please include the phrase to trigger on as well for your skill
 
 | Status              | Skill Name                                                                      | Description<br>```"phrase to trigger"```    |
 | ------------------- | ------------------------------------------------------------------------------- | --------------------------------------------|
-| :heavy_check_mark:  | [AVmusic](https://github.com/reginaneon/AVmusic.reginaneon/blob/master/README.md)| Provides the video/audio playback of various music requested by the user.<br>```play some imagine dragons music``` |
 | :heavy_check_mark:  | [CaffeineWiz](https://github.com/reginaneon/caffeinewiz.reginaneon/blob/master/README.md)| Request caffeine content of selected drinks<br>```what's the caffeine content of *drink*?```|
 | :heavy_check_mark:  | [mycroft-hue](https://github.com/ChristopherRogers1991/mycroft-hue/blob/master/README.md)| Control your Phillips Hue lights<br>```turn on the lights``` |
 | :heavy_check_mark:  | [Homeassistant](https://github.com/btotharye/mycroft-homeassistant#readme)               | Control your devices in home-assistant<br>```"turn on office"``` |

--- a/README.md
+++ b/README.md
@@ -143,5 +143,5 @@ wiki pages.  Also please include the phrase to trigger on as well for your skill
 | Status              | Skill Name                                                                      | Description<br>```"phrase to trigger"```    |
 | ------------------- | ------------------------------------------------------------------------------- | --------------------------------------------|
 | :heavy_check_mark:  | [AVmusic](https://github.com/reginaneon/AVmusic.reginaneon/blob/master/README.md)| Provides the video/audio playback of various music requested by the user.<br>```play some imagine dragons music``` |
-| :heavy_check_mark:  | [CaffeineWiz](https://github.com/reginaneon/caffeinewiz.reginaneon/blob/master/README.md)| Request caffeine content of selected drinks<br>```what's the caffeine content of *drink*?```|
+| :heavy_check_mark:  | [CaffeineWiz](https://github.com/reginaneon/caffeinewiz.reginaneon/blob/master/README.md)| Request caffeine content of selected drinks<br>```what's the caffeine content of *drink*?```| 
 | :heavy_check_mark:  | [mycroft-hue](https://github.com/ChristopherRogers1991/mycroft-hue/blob/master/README.md)| Control your Phillips Hue lights<br>```turn on the lights``` |

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ wiki pages.  Also please include the phrase to trigger on as well for your skill
 | Status              | Skill Name                                                                      | Description<br>```"phrase to trigger"```    |
 | ------------------- | ------------------------------------------------------------------------------- | --------------------------------------------|
 | :heavy_check_mark:  | [AVmusic](https://github.com/reginaneon/AVmusic.reginaneon/blob/master/README.md)| Provides the video/audio playback of various music requested by the user.<br>```play some imagine dragons music``` |
-| :heavy_check_mark:  | [CaffeineWiz](https://github.com/reginaneon/caffeinewiz.reginaneon/blob/master/README.md)| Request caffeine content of selected drinks<br>```what's the caffeine content of *drink*?```| 
+| :heavy_check_mark:  | [CaffeineWiz](https://github.com/reginaneon/caffeinewiz.reginaneon/blob/master/README.md)| Request caffeine content of selected drinks<br>```what's the caffeine content of *drink*?```|
 | :heavy_check_mark:  | [mycroft-hue](https://github.com/ChristopherRogers1991/mycroft-hue/blob/master/README.md)| Control your Phillips Hue lights<br>```turn on the lights``` |
 | :heavy_check_mark:  | [Homeassistant](https://github.com/btotharye/mycroft-homeassistant#readme)               | Control your devices in home-assistant<br>```"turn on office"``` |
 | :heavy_check_mark:  | [Plasma Activities Skill](https://github.com/AIIX/plasma-activities-skill#readme)| Control KDE Plasma 5 Activities with Mycroft```show/create/switch/remove activity [name]``` |

--- a/README.md
+++ b/README.md
@@ -149,6 +149,6 @@ wiki pages.  Also please include the phrase to trigger on as well for your skill
 | :heavy_check_mark:  | [mycroft-hue](https://github.com/ChristopherRogers1991/mycroft-hue/blob/master/README.md)| Control your Phillips Hue lights<br>```turn on the lights``` |
 | :heavy_check_mark:  | [Homeassistant](https://github.com/btotharye/mycroft-homeassistant#readme)               | Control your devices in home-assistant<br>```"turn on office"``` |
 | :heavy_check_mark:  | [Plasma Activities Skill](https://github.com/AIIX/plasma-activities-skill#readme)| Control KDE Plasma 5 Activities with Mycroft```show/create/switch/remove activity [name]``` |
-| :heavy_check_mark:  | [translate-skill](https://github.com/jcasoft/translate-skill/tree/84db4da986c1ae165d4c31bb5f907398feb19326#readme)               | Translate phrases into several languages<br>```"translate good morning into japanese"``` |
+| :heavy_check_mark:  | [translate-skill](https://github.com/jcasoft/translate-skill/tree/84db4da986c1ae165d4c31bb5f907398feb19326#readme)              | Translate phrases into several languages<br>```"translate good morning into japanese"``` |
 | :heavy_check_mark:  | [Zork](https://github.com/forslund/white-house-adventure/blob/master/README.md)| Play the old school adventure game<br>```and explore the underground empire``` |
 

--- a/README.md
+++ b/README.md
@@ -142,4 +142,6 @@ wiki pages.  Also please include the phrase to trigger on as well for your skill
 
 | Status              | Skill Name                                                                      | Description<br>```"phrase to trigger"```    |
 | ------------------- | ------------------------------------------------------------------------------- | --------------------------------------------|
+| :heavy_check_mark:  | [AVmusic](https://github.com/reginaneon/AVmusic.reginaneon/blob/master/README.md)| Provides the video/audio playback of various music requested by the user.<br>```play some imagine dragons music``` |
+| :heavy_check_mark:  | [CaffeineWiz](https://github.com/reginaneon/caffeinewiz.reginaneon/blob/master/README.md)| Request caffeine content of selected drinks<br>```what's the caffeine content of *drink*?```|
 | :heavy_check_mark:  | [mycroft-hue](https://github.com/ChristopherRogers1991/mycroft-hue/blob/master/README.md)| Control your Phillips Hue lights<br>```turn on the lights``` |


### PR DESCRIPTION
CaffeineWiz
Provides the caffeine content of various drinks on request.
Adding back the CaffeineWiz skill: updated to Python 3.4+, merged in German translation, changed "drinkList"'s pathway and export patterns, added metric conversions for European users.

## Checklist:
  - [x] Used [Meta Editor](http://rawgit.com/MycroftAI/mycroft-skills/master/meta_editor.html) to generate the skill README
  - [x] Skill has been tested and works
  - [x] Read and verified approval process - https://mycroft.ai/documentation/skills/skills-acceptance-process (Can require a community member vouching for skill)
  - [x] README.md has been updated with the following:
  ```
+[submodule "CaffeineWiz"]
+ 	path = CaffeineWiz
+	url = https://github.com/reginaneon/CaffeineWiz.git
 ```
 - [x] README.md has been updated with your skill phrase and description
