### PR TITLE
Add Plasma User Control Skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -148,3 +148,6 @@
 [submodule "chatbot"]
 	path = chatbot
 	url = https://github.com/forslund/fallback-aiml.git
+[submodule "plasma-user-control-skill"]
+	path = plasma-user-control-skill
+	url = https://github.com/AIIX/plasma-user-control-skill

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ wiki pages.  Also please include the phrase to trigger on as well for your skill
 | :heavy_check_mark:  | [mycroft-hue](https://github.com/ChristopherRogers1991/mycroft-hue/blob/master/README.md)| Control your Phillips Hue lights<br>```turn on the lights``` |
 | :heavy_check_mark:  | [Homeassistant](https://github.com/btotharye/mycroft-homeassistant#readme)               | Control your devices in home-assistant<br>```"turn on office"``` |
 | :heavy_check_mark:  | [Plasma Activities Skill](https://github.com/AIIX/plasma-activities-skill#readme)| Control KDE Plasma 5 Activities with Mycroft```show/create/switch/remove activity [name]``` |
+| :heavy_check_mark:  | [Plasma User Control Skill](https://github.com/AIIX/plasma-user-control-skill#readme)| Control KDE Plasma 5 System Internals with Mycroft```lock screen/switch users/logout/control brightness/touchpad/add widgets/add and control panels``` |
 | :heavy_check_mark:  | [Today In History Skill](https://github.com/Geeked-Out-Solutions/mycroft-skill-today-in-history#readme)| Gives a random event from today in history```today in history``` |
 | :heavy_check_mark:  | [translate-skill](https://github.com/jcasoft/translate-skill/tree/84db4da986c1ae165d4c31bb5f907398feb19326#readme)               | Translate phrases into several languages<br>```"translate good morning into japanese"``` |
 | :heavy_check_mark:  | [Zork](https://github.com/forslund/white-house-adventure/blob/master/README.md)| Play the old school adventure game<br>```and explore the underground empire``` |


### PR DESCRIPTION
## Description:

This skill integrates Plasma 5 Desktop Internals with Mycroft which enables users to Lock Screen, Switch Users, Logout, Control Brightness, Control Panel Positions, Control Klipper, Control Work-spaces, Control Compositor, Add Widgets on Plasma Desktop.

## Checklist:
  - [x] Used [Meta Editor](http://rawgit.com/MycroftAI/mycroft-skills/master/meta_editor.html) to generate the skill README
  - [x] Skill has been tested and works
  - [x] Read and verified approval process - https://mycroft.ai/documentation/skills/skills-acceptance-process (Can require a community member vouching for skill)
  - [x] README.md has been updated with the following:
  ```
  +[submodule "NAME OF YOUR SKILL"]
  +	path = name-of-your-skill-skill
  +	url = URL.FOR.YOUR.SKILL.git
 ```
 - [x] README.md has been updated with your skill phrase and description
