### PR TITLE
Move #core Skills out of DEFAULT and into each DEFAULT.platform file,…

### DIFF
--- a/DEFAULT-SKILLS
+++ b/DEFAULT-SKILLS
@@ -7,26 +7,3 @@ mycroft-naptime
 mycroft-playback-control
 mycroft-speak
 mycroft-volume
-
-# common
-mycroft-fallback-duck-duck-go
-#fallback-aiml
-fallback-wolfram-alpha
-fallback-unknown
-mycroft-alarm
-mycroft-audio-record
-mycroft-date-time
-mycroft-hello-world
-mycroft-ip
-mycroft-joke
-mycroft-npr-news
-mycroft-personal
-mycroft-reminder
-mycroft-singing
-mycroft-spelling
-mycroft-stock
-mycroft-support-helper
-mycroft-timer
-mycroft-weather
-mycroft-wiki
-mycroft-version-checker

--- a/DEFAULT-SKILLS
+++ b/DEFAULT-SKILLS
@@ -7,3 +7,26 @@ mycroft-naptime
 mycroft-playback-control
 mycroft-speak
 mycroft-volume
+
+# common
+mycroft-fallback-duck-duck-go
+#fallback-aiml
+fallback-wolfram-alpha
+fallback-unknown
+mycroft-alarm
+mycroft-audio-record
+mycroft-date-time
+mycroft-hello-world
+mycroft-ip
+mycroft-joke
+mycroft-npr-news
+mycroft-personal
+mycroft-reminder
+mycroft-singing
+mycroft-spelling
+mycroft-stock
+mycroft-support-helper
+mycroft-timer
+mycroft-weather
+mycroft-wiki
+mycroft-version-checker

--- a/DEFAULT-SKILLS.kde
+++ b/DEFAULT-SKILLS.kde
@@ -5,3 +5,26 @@ krunner-search-skill
 plasma-activities-skill
 plasma-user-control-skill
 plasma-mycroftplasmoid-control
+
+# common
+mycroft-fallback-duck-duck-go
+#fallback-aiml
+fallback-wolfram-alpha
+fallback-unknown
+mycroft-alarm
+mycroft-audio-record
+mycroft-date-time
+mycroft-hello-world
+mycroft-ip
+mycroft-joke
+mycroft-npr-news
+mycroft-personal
+mycroft-reminder
+mycroft-singing
+mycroft-spelling
+mycroft-stock
+mycroft-support-helper
+mycroft-timer
+mycroft-weather
+mycroft-wiki
+mycroft-version-checker

--- a/DEFAULT-SKILLS.kde
+++ b/DEFAULT-SKILLS.kde
@@ -22,9 +22,6 @@ mycroft-personal
 mycroft-reminder
 mycroft-singing
 mycroft-spelling
-mycroft-stock
 mycroft-support-helper
 mycroft-timer
-mycroft-weather
 mycroft-wiki
-mycroft-version-checker

--- a/DEFAULT-SKILLS.kde
+++ b/DEFAULT-SKILLS.kde
@@ -7,6 +7,9 @@ plasma-user-control-skill
 plasma-mycroftplasmoid-control
 
 # common
+mycroft-playback-control
+mycroft-speak
+mycroft-volume
 mycroft-fallback-duck-duck-go
 #fallback-aiml
 fallback-wolfram-alpha

--- a/DEFAULT-SKILLS.kde
+++ b/DEFAULT-SKILLS.kde
@@ -24,4 +24,3 @@ mycroft-singing
 mycroft-spelling
 mycroft-support-helper
 mycroft-timer
-mycroft-wiki

--- a/DEFAULT-SKILLS.mycroft_mark_1
+++ b/DEFAULT-SKILLS.mycroft_mark_1
@@ -5,6 +5,9 @@ mycroft-spotify
 pandora-skill
 
 # common
+mycroft-playback-control
+mycroft-speak
+mycroft-volume
 mycroft-fallback-duck-duck-go
 #fallback-aiml
 fallback-wolfram-alpha

--- a/DEFAULT-SKILLS.mycroft_mark_1
+++ b/DEFAULT-SKILLS.mycroft_mark_1
@@ -3,3 +3,26 @@ mycroft-mark-1-demo
 mycroft-mark-1
 mycroft-spotify
 pandora-skill
+
+# common
+mycroft-fallback-duck-duck-go
+#fallback-aiml
+fallback-wolfram-alpha
+fallback-unknown
+mycroft-alarm
+mycroft-audio-record
+mycroft-date-time
+mycroft-hello-world
+mycroft-ip
+mycroft-joke
+mycroft-npr-news
+mycroft-personal
+mycroft-reminder
+mycroft-singing
+mycroft-spelling
+mycroft-stock
+mycroft-support-helper
+mycroft-timer
+mycroft-weather
+mycroft-wiki
+mycroft-version-checker

--- a/DEFAULT-SKILLS.picroft
+++ b/DEFAULT-SKILLS.picroft
@@ -1,6 +1,9 @@
 # picroft
 
 # common
+mycroft-playback-control
+mycroft-speak
+mycroft-volume
 mycroft-fallback-duck-duck-go
 #fallback-aiml
 fallback-wolfram-alpha

--- a/DEFAULT-SKILLS.picroft
+++ b/DEFAULT-SKILLS.picroft
@@ -1,1 +1,24 @@
 # picroft
+
+# common
+mycroft-fallback-duck-duck-go
+#fallback-aiml
+fallback-wolfram-alpha
+fallback-unknown
+mycroft-alarm
+mycroft-audio-record
+mycroft-date-time
+mycroft-hello-world
+mycroft-ip
+mycroft-joke
+mycroft-npr-news
+mycroft-personal
+mycroft-reminder
+mycroft-singing
+mycroft-spelling
+mycroft-stock
+mycroft-support-helper
+mycroft-timer
+mycroft-weather
+mycroft-wiki
+mycroft-version-checker


### PR DESCRIPTION
This PR is based on discussions w/ @el-tocino, @AIIX and @penrods around the need to slightly modify the DEFAULT file so that it doesn't overwrite Skills that are customised on a per-platform basis, like `skill-wiki` is for the KDE platform. 

This is a really simple change and _should_ be non-breaking, but definitely needs an experienced eye to review because of the large scope that the DEFAULT.* files have. 

#### Suggested test sequence to validate this PR: 

* Using the KDE enclosure, remove all Skills. Run `msm default` to bring in default Skills. 
* Ensure that the offending Skills (stocks, weather - sorry I couldn't find the wikipedia Skill in the #core list) are not installed. 
_This tests the intended outcome for KDE_

* Using the Mark 1 enclosure, remove all Skills. Run `msm default` to bring in default Skills. 
* Ensure that all the default Skills are loaded. 
_This tests that we don't adversely impact other Skills with the change_
