### PR TITLE
Remove unwanted space in the generated icon URL

### DIFF
--- a/meta_editor.html
+++ b/meta_editor.html
@@ -477,7 +477,7 @@ function generateREADME() {
     icon_url = elIcon.value;
   else
     icon_url = "https://rawgithub.com/FortAwesome/Font-Awesome/master/advanced-options/raw-svg/solid/"+elIcon.value+".svg";
-  markdown = "# <img src='"+icon_url+" ' card_color='"+elIconColor.value+"' width='50' height='50' style='vertical-align:bottom'/>";
+  markdown = "# <img src='"+icon_url+"' card_color='"+elIconColor.value+"' width='50' height='50' style='vertical-align:bottom'/>";
   markdown += " " + elName.value + "\n";
 
   markdown += elShortDesc.value + "\n\n";


### PR DESCRIPTION
A space was accidentally being placed a the end of the URL for the icon preview in the generated README.md