### PR TITLE
Add a HTML color picker to the meta-generator for README files #502

### DIFF
--- a/meta_editor.html
+++ b/meta_editor.html
@@ -865,7 +865,7 @@ function initialize() {
                         <tr>
                             <td style="vertical-align:top">Preview:<br/><i id="icon_preview" class="fa-2x fas fa-robot" style="color:#40DBB0;"></i><img id="img_preview" src="" width="41" height="41" style="display:none;"/></td>
                             <td width="70%">Font Awesome Name / or image URL:<input type="text" id="icon" maxlength="255" placeholder="robot" value="robot" onkeyup="update_icon()"/></td>
-                            <td>Color:<br/><input type="text" id="icon_color" maxlength="7" placeholder="#40DBB0" value="#40dbb0" onkeyup="update_icon()"/></td>
+                            <td>Color:<br/><input id="icon_color" maxlength="7" type="color" name="color" value="#40dbb0" onkeyup="update_icon()"/></td>
                         </table>
                     </div>
 					<span>Go to <a href="https://fontawesome.com/cheatsheet" target="_blank">Font Awesome</a>,


### PR DESCRIPTION
#502 
## Description:

Added an HTML color picker to the meta-generator for README files


## Checklist:
  - README.md has been updated with the following:
 
![colorpicker](https://user-images.githubusercontent.com/30777215/46296394-e961fc00-c5b7-11e8-9613-80ac9d297a53.PNG)

