### PR TITLE
Add HTML color picker to the meta-generator #502

### DIFF
--- a/meta_editor.html
+++ b/meta_editor.html
@@ -802,10 +802,10 @@ function copyToREADMEClipboard()
     elem.style.backgroundColor = "#FFF";
 }
 
-function initializeColorPicker(elSelector){
+function initializeColorPicker(elSelector,defaultColorHex,onChangeCallback){
     color_picker = new Pickr({
         el: elSelector,
-        default: '#40DBB0',
+        default: defaultColorHex,
         components: {
             preview: true,
             opacity: true,
@@ -820,10 +820,10 @@ function initializeColorPicker(elSelector){
             }
         },
         onChange(hsva, instance) {
-            update_icon();
+            onChangeCallback();
         },
         onSave(hsva, instance) {
-            update_icon();
+            onChangeCallback();
         }
     });
 }
@@ -832,7 +832,7 @@ function initialize() {
     var evt = [];
     evt.currentTarget = document.getElementById("Intro");
     toTab(evt);
-    initializeColorPicker('#icon_color');
+    initializeColorPicker('#icon_color','#40DBB0',update_icon);
 }
 
 </script>

--- a/meta_editor.html
+++ b/meta_editor.html
@@ -455,7 +455,7 @@
     <script src="https://cdn.jsdelivr.net/npm/pickr-widget/dist/pickr.min.js"></script>
 
 	<script type="text/javascript">
-var color_picker = null;
+var colorPicker = null;
 	//auto expand textarea
 function adjust_textarea(h) {
   new_height = h.scrollHeight;
@@ -664,7 +664,7 @@ function generatePreviewCard()
   else
   {
       document.getElementById("icon_small").className = "fa-3x fas fa-"+elIcon.value;
-      document.getElementById("icon_small").style.color= color_picker._color.toHEX().toString();
+      document.getElementById("icon_small").style.color= colorPicker._color.toHEX().toString();
       document.getElementById("img_icon_small").style.display = "none";
       document.getElementById("icon_small").style.display = "inline";
   }
@@ -701,7 +701,7 @@ function generatePreviewDetail()
   // TODO: Validate icon and color
   var elIcon = document.getElementById("icon");
   document.getElementById("icon_large").className = "fa-3x fas fa-"+elIcon.value;
-  document.getElementById("icon_large").style.color= color_picker._color.toHEX().toString();
+  document.getElementById("icon_large").style.color= colorPicker._color.toHEX().toString();
 
   if (elIcon.value.startsWith("http"))
   {
@@ -712,7 +712,7 @@ function generatePreviewDetail()
   else
   {
       document.getElementById("icon_large").className = "fa-3x fas fa-"+elIcon.value;
-      document.getElementById("icon_large").style.color= color_picker._color.toHEX().toString();
+      document.getElementById("icon_large").style.color= colorPicker._color.toHEX().toString();
       document.getElementById("img_icon_large").style.display = "none";
       document.getElementById("icon_large").style.display = "inline";
   }
@@ -785,7 +785,7 @@ function update_icon()
     else
     {
         elPreview.className = "fa-2x fas fa-"+elIcon.value;
-        elPreview.style.color = color_picker._color.toHEX().toString();
+        elPreview.style.color = colorPicker._color.toHEX().toString();
         elPreview.style.display = "block";
         elImgPreview.style.display = "none";
     }
@@ -803,7 +803,7 @@ function copyToREADMEClipboard()
 }
 
 function initializeColorPicker(elSelector,defaultColorHex,onChangeCallback){
-    color_picker = new Pickr({
+    return new Pickr({
         el: elSelector,
         default: defaultColorHex,
         components: {
@@ -832,7 +832,7 @@ function initialize() {
     var evt = [];
     evt.currentTarget = document.getElementById("Intro");
     toTab(evt);
-    initializeColorPicker('#icon_color','#40DBB0',update_icon);
+    colorPicker = initializeColorPicker('#icon_color','#40DBB0',update_icon);
 }
 
 </script>

--- a/meta_editor.html
+++ b/meta_editor.html
@@ -451,7 +451,11 @@
 
     <script type="application/javascript" src="https://cdn.rawgit.com/jgm/commonmark.js/master/dist/commonmark.js"></script>
     
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pickr-widget/dist/pickr.min.css"/>
+    <script src="https://cdn.jsdelivr.net/npm/pickr-widget/dist/pickr.min.js"></script>
+
 	<script type="text/javascript">
+var color_picker = null;
 	//auto expand textarea
 function adjust_textarea(h) {
   new_height = h.scrollHeight;
@@ -659,9 +663,8 @@ function generatePreviewCard()
   }
   else
   {
-      var elClr = document.getElementById("icon_color");
       document.getElementById("icon_small").className = "fa-3x fas fa-"+elIcon.value;
-      document.getElementById("icon_small").style.color= elClr.value;
+      document.getElementById("icon_small").style.color= color_picker._color.toHEX().toString();
       document.getElementById("img_icon_small").style.display = "none";
       document.getElementById("icon_small").style.display = "inline";
   }
@@ -697,9 +700,8 @@ function generatePreviewDetail()
   
   // TODO: Validate icon and color
   var elIcon = document.getElementById("icon");
-  var elClr = document.getElementById("icon_color");
   document.getElementById("icon_large").className = "fa-3x fas fa-"+elIcon.value;
-  document.getElementById("icon_large").style.color= elClr.value;
+  document.getElementById("icon_large").style.color= color_picker._color.toHEX().toString();
 
   if (elIcon.value.startsWith("http"))
   {
@@ -709,9 +711,8 @@ function generatePreviewDetail()
   }
   else
   {
-      var elClr = document.getElementById("icon_color");
       document.getElementById("icon_large").className = "fa-3x fas fa-"+elIcon.value;
-      document.getElementById("icon_large").style.color= elClr.value;
+      document.getElementById("icon_large").style.color= color_picker._color.toHEX().toString();
       document.getElementById("img_icon_large").style.display = "none";
       document.getElementById("icon_large").style.display = "inline";
   }
@@ -771,7 +772,6 @@ function checkDevices()
 function update_icon()
 {
     var elIcon = document.getElementById("icon");
-    var elClr = document.getElementById("icon_color");
 
     var elPreview = document.getElementById("icon_preview");
     var elImgPreview = document.getElementById("img_preview");
@@ -785,7 +785,7 @@ function update_icon()
     else
     {
         elPreview.className = "fa-2x fas fa-"+elIcon.value;
-        elPreview.style.color = elClr.value;
+        elPreview.style.color = color_picker._color.toHEX().toString();
         elPreview.style.display = "block";
         elImgPreview.style.display = "none";
     }
@@ -802,10 +802,37 @@ function copyToREADMEClipboard()
     elem.style.backgroundColor = "#FFF";
 }
 
+function initializeColorPicker(elSelector){
+    color_picker = new Pickr({
+        el: elSelector,
+        default: '#40DBB0',
+        components: {
+            preview: true,
+            opacity: true,
+            hue: true,
+            interaction: {
+                hex: true,
+                rgba: true,
+                hsva: true,
+                input: true,
+                clear: true,
+                save: true
+            }
+        },
+        onChange(hsva, instance) {
+            update_icon();
+        },
+        onSave(hsva, instance) {
+            update_icon();
+        }
+    });
+}
+
 function initialize() {
     var evt = [];
     evt.currentTarget = document.getElementById("Intro");
     toTab(evt);
+    initializeColorPicker('#icon_color');
 }
 
 </script>
@@ -865,7 +892,9 @@ function initialize() {
                         <tr>
                             <td style="vertical-align:top">Preview:<br/><i id="icon_preview" class="fa-2x fas fa-robot" style="color:#40DBB0;"></i><img id="img_preview" src="" width="41" height="41" style="display:none;"/></td>
                             <td width="70%">Font Awesome Name / or image URL:<input type="text" id="icon" maxlength="255" placeholder="robot" value="robot" onkeyup="update_icon()"/></td>
-                            <td>Color:<br/><input type="text" id="icon_color" maxlength="7" placeholder="#40DBB0" value="#40dbb0" onkeyup="update_icon()"/></td>
+                            <td>Color:<br/>
+                            	<div id="icon_color"></div>
+                            </td>
                         </table>
                     </div>
 					<span>Go to <a href="https://fontawesome.com/cheatsheet" target="_blank">Font Awesome</a>,


### PR DESCRIPTION
## Description:

Improve color picker UI for meta-generator.
Used [MIT Licensed](https://github.com/Simonwep/pickr/blob/master/LICENSE) JS library [Pickr](https://github.com/Simonwep/pickr/) by [Simonwep](https://github.com/Simonwep) for color picker.
Awesome library btw, written in pure JS and no library dependency 👍.

Preview/demo:
https://rawgit.com/MycroftAI/mycroft-skills/a7fdf1298a5386e37460c67a60397ddd816c8997/meta_editor.html

Addressing issue:
https://github.com/MycroftAI/mycroft-skills/issues/502

## Checklist:
  - [x] has been tested and works