### PR TITLE
Meta generator's color picker bugfix & improvement

### DIFF
--- a/meta_editor.html
+++ b/meta_editor.html
@@ -480,7 +480,7 @@ function generateREADME() {
     icon_url = elIcon.value;
   else
     icon_url = "https://rawgithub.com/FortAwesome/Font-Awesome/master/advanced-options/raw-svg/solid/"+elIcon.value+".svg";
-  markdown = "# <img src='"+icon_url+"' card_color='"+colorPicker._color.toHEX().toString()+"' width='50' height='50' style='vertical-align:bottom'/>";
+  markdown = "# <img src='"+icon_url+"' card_color='"+colorPicker.getColor().toHEX().toString()+"' width='50' height='50' style='vertical-align:bottom'/>";
   markdown += " " + elName.value + "\n";
 
   markdown += elShortDesc.value + "\n\n";
@@ -663,7 +663,7 @@ function generatePreviewCard()
   else
   {
       document.getElementById("icon_small").className = "fa-3x fas fa-"+elIcon.value;
-      document.getElementById("icon_small").style.color= colorPicker._color.toHEX().toString();
+      document.getElementById("icon_small").style.color= colorPicker.getColor().toHEX().toString();
       document.getElementById("img_icon_small").style.display = "none";
       document.getElementById("icon_small").style.display = "inline";
   }
@@ -700,7 +700,7 @@ function generatePreviewDetail()
   // TODO: Validate icon and color
   var elIcon = document.getElementById("icon");
   document.getElementById("icon_large").className = "fa-3x fas fa-"+elIcon.value;
-  document.getElementById("icon_large").style.color= colorPicker._color.toHEX().toString();
+  document.getElementById("icon_large").style.color= colorPicker.getColor().toHEX().toString();
 
   if (elIcon.value.startsWith("http"))
   {
@@ -711,7 +711,7 @@ function generatePreviewDetail()
   else
   {
       document.getElementById("icon_large").className = "fa-3x fas fa-"+elIcon.value;
-      document.getElementById("icon_large").style.color= colorPicker._color.toHEX().toString();
+      document.getElementById("icon_large").style.color= colorPicker.getColor().toHEX().toString();
       document.getElementById("img_icon_large").style.display = "none";
       document.getElementById("icon_large").style.display = "inline";
   }
@@ -784,7 +784,7 @@ function update_icon()
     else
     {
         elPreview.className = "fa-2x fas fa-"+elIcon.value;
-        elPreview.style.color = colorPicker._color.toHEX().toString();
+        elPreview.style.color = colorPicker.getColor().toHEX().toString();
         elPreview.style.display = "block";
         elImgPreview.style.display = "none";
     }

--- a/meta_editor.html
+++ b/meta_editor.html
@@ -472,7 +472,6 @@ function generateREADME() {
 
   var elem = document.getElementById("output");
   var elIcon = document.getElementById("icon");
-  var elIconColor = document.getElementById("icon_color");
   var elName = document.getElementById("name");
   var elShortDesc = document.getElementById("short_desc");
   var elLongDesc = document.getElementById("long_desc");
@@ -481,7 +480,7 @@ function generateREADME() {
     icon_url = elIcon.value;
   else
     icon_url = "https://rawgithub.com/FortAwesome/Font-Awesome/master/advanced-options/raw-svg/solid/"+elIcon.value+".svg";
-  markdown = "# <img src='"+icon_url+"' card_color='"+elIconColor.value+"' width='50' height='50' style='vertical-align:bottom'/>";
+  markdown = "# <img src='"+icon_url+"' card_color='"+colorPicker._color.toHEX().toString()+"' width='50' height='50' style='vertical-align:bottom'/>";
   markdown += " " + elName.value + "\n";
 
   markdown += elShortDesc.value + "\n\n";

--- a/meta_editor.html
+++ b/meta_editor.html
@@ -805,17 +805,18 @@ function initializeColorPicker(elSelector,defaultColorHex,onChangeCallback){
     return new Pickr({
         el: elSelector,
         default: defaultColorHex,
+	comparison: false,
         components: {
             preview: true,
-            opacity: true,
+            opacity: false,
             hue: true,
             interaction: {
                 hex: true,
                 rgba: true,
                 hsva: true,
                 input: true,
-                clear: true,
-                save: true
+                clear: false,
+                save: false
             }
         },
         onChange(hsva, instance) {


### PR DESCRIPTION
## Description:

Addressing:
This feedback: https://github.com/MycroftAI/mycroft-skills/pull/592#issuecomment-426488101

Disable following color picker feature:
- Opacity slider is unnecessary.
- Save button is unnecessary as color update happens in real time anyway.
- Clear button is unnecessary as we should not use blank color.

Bugfix:
- Fixed: I may have introduced small bug because I forgot to change one color value accessor in this line: https://github.com/MycroftAI/mycroft-skills/blob/18.08/meta_editor.html#L484 

Use proper colorPicker value getter function:
- replace color value getter from `._color` to proper `.getColor()`

## Preview/demo
https://rawgit.com/rizdaprasetya/mycroft-skills/patch-2/meta_editor.html

## Checklist:
  - [x] has been tested and works