### PR TITLE
Move JS dependency away from rawgit to jsdelivr

### DIFF
--- a/meta_editor.html
+++ b/meta_editor.html
@@ -449,7 +449,7 @@
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700,900">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous">
 
-    <script type="application/javascript" src="https://cdn.rawgit.com/jgm/commonmark.js/master/dist/commonmark.js"></script>
+    <script type="application/javascript" src="https://cdn.jsdelivr.net/npm/commonmark@0.28.1/dist/commonmark.js"></script>
     
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pickr-widget/dist/pickr.min.css"/>
     <script src="https://cdn.jsdelivr.net/npm/pickr-widget/dist/pickr.min.js"></script>


### PR DESCRIPTION
## Description:

Rawgit is [shutting down](https://rawgit.com/) 😢 

> RawGit has reached the end of its useful life
October 8, 2018
RawGit is now in a sunset phase and will soon shut down. It's been a fun five years, but all things must end.
GitHub repositories that served content through RawGit within the last month will continue to be served until at least October of 2019. URLs for other repositories are no longer being served.
If you're currently using RawGit, please stop using it as soon as you can.

I moved away JS dependency from rawgit to jsdelivr to avoid future dependency issue once rawgit.com has shut down.

## Checklist:
  - [x] Has been tested and works
