### PR TITLE
Change meta_editor hotlink from rawgit to rawgithack. Fixes #618

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The official home of **Skills** for the Mycroft ecosystem.  These **Skills** are
 
 # Meta Editor
 
-If you are building **Skills**, please ensure that you use the [Meta Editor](https://rawgit.com/MycroftAI/mycroft-skills/18.08/meta_editor.html) for your README.md file. The **Skills** list is generated from parsing the README.md files. 
+If you are building **Skills**, please ensure that you use the [Meta Editor](https://raw.githack.com/MycroftAI/mycroft-skills/18.08/meta_editor.html) for your README.md file. The **Skills** list is generated from parsing the README.md files. 
 
 # Skills Documentation
 


### PR DESCRIPTION
## Description:
This should fix #618 
[Rawgithack](https://github.com/neoascetic/rawgithack) is similar implementation of Rawgit.
I changed `meta_editor.html` hotlink from Rawgit to Rawgithack, so that people can still access the hosted html page easily using browser.

What do you think? Feel free to edit or suggest alternative.

## Checklist:
  - [x] Has been tested and works 

## Demo
[https://raw.githack.com/MycroftAI/mycroft-skills/18.08/meta_editor.html](https://raw.githack.com/MycroftAI/mycroft-skills/18.08/meta_editor.html)