### PR TITLE
Add readytowork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -139,3 +139,6 @@
 [submodule "picroft-google-aiy-voicekit"]
 	path = picroft-google-aiy-voicekit
 	url = https://github.com/andlo/picroft-google-aiy-voicekit-skill.git
+[submodule "readytowork"]
+	path = readytowork
+	url = https://github.com/fortwally/ready-to-work-skill.git


### PR DESCRIPTION

## Info

This PR adds the new skill, [readytowork](https://github.com/fortwally/ready-to-work-skill), to the skills repo.

## Description


This is for a headless picroft environment to let the user know when the raspberry pi has booted and mycroft is ready to work.
There are no intents, it is a one shot spoken phrase.
In other environments there are other indicators that mycroft is ready.


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.10</sub>