### PR TITLE
Add Sonos-control

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -169,3 +169,6 @@
 [submodule "skill-aircrack"]
 	path = skill-aircrack
 	url = https://github.com/JonStratton/skill-aircrack
+[submodule "Sonos-control"]
+	path = Sonos-control
+	url = https://github.com/fortwally/sonos-control-skill.git


### PR DESCRIPTION

## Info

This PR adds the new skill, [Sonos-control](https://github.com/fortwally/sonos-control-skill), to the skills repo.

## Description


Allow control of Sonos speakers from Mycroft.
Assumes all speakers are in one group.


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.12</sub>