### PR TITLE
Add auto-volume

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -172,3 +172,6 @@
 [submodule "remember"]
 	path = remember
 	url = https://github.com/luke5sky/remember-skill.git
+[submodule "auto-volume"]
+	path = auto-volume
+	url = https://github.com/andlo/auto-volume-skill.git


### PR DESCRIPTION

## Info

This PR adds the new skill, [auto-volume](https://github.com/andlo/auto-volume-skill), to the skills repo.

## Description


This skill lets Mycroft deside when to use high, normal or low volume. Mycrofts keeps monitoring the mic level, and from that deside what volume level is right to use.

As it is not easy to know what is high and what is low noice level, the skill vil adap over time. The skill notise the higest and lowest messured level, and adjust acording to that.

The skill stops adjusting volume if another skill is using the speaker or if Mycroft himself is talking.

The skill can be activated og deactivatet by the command "Hey Mycroft, set auto volume off" or "Hey Mycroft, set auto volume on"



<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.12</sub>