### PR TITLE
Add mattermost

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -196,3 +196,6 @@
 [submodule "fallback-query"]
 	path = fallback-query
 	url = https://github.com/MycroftAI/skill-query.git
+[submodule "mattermost"]
+	path = mattermost
+	url = https://github.com/domcross/mattermost-for-mycroft-skill.git


### PR DESCRIPTION

## Info

This PR adds the new skill, [mattermost](https://github.com/domcross/mattermost-for-mycroft-skill), to the skills repo.

## Description


In your skill settings at home.mycroft.ai you must enter your username (as given in Mattermost account settings) and your personal access token. In case you do not have a token you can specify your login-id (usually that is your email) and your password. NOTE: your password will be stored in clear text in your settings.json!)

There is also the option to set the time interval between refresh/check for updates. When monitoring is active the skill will use that time period for automated checking.
The option "notify on updates" is only applicable when monitoring is active - when option is activated Mycroft willl speak out loud the number of unread messages and mentions.

You can also specify the server configuration. Default settings are for chat.mycroft.ai so you should already be ready to go. NOTE: change anything here and you are on your own! ;-)


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.12</sub>