### PR TITLE
Add speedtest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -187,3 +187,6 @@
 [submodule "fairytalez"]
 	path = fairytalez
 	url = https://github.com/andlo/fairytalez-skill.git
+[submodule "speedtest"]
+	path = speedtest
+	url = https://github.com/luke5sky/speedtest-skill.git


### PR DESCRIPTION

## Info

This PR adds the new skill, [speedtest](https://github.com/luke5sky/speedtest-skill), to the skills repo.

## Description


Run a speedtest with Mycroft.
This skill uses the speedtest-cli (https://github.com/sivel/speedtest-cli) which runs an internet bandwidth test using speedtest.net.

Be aware that this speedtest relies on the capability of the network-adapter of your Mycroft device.

Examples for Raspberry Pi:
- Raspberry Pi 3 B  onboard WiFi: max. ~40 Mbit/s, onboard LAN: max. ~100 Mbit/s
- Raspberry Pi 3 B+ onboard WiFi: max. ~100 Mbit/s, onboard LAN: max. ~225 Mbit/s

If a Raspberry Pi 3 B - connected to WiFi - runs Mycroft you won't get more than 40 Mbit/s from the speedtest despite your internet connection may have more bandwith.


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.12</sub>