### PR TITLE
Adding roomba-serial-command-skill.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -187,3 +187,6 @@
 [submodule "fairytalez"]
 	path = fairytalez
 	url = https://github.com/andlo/fairytalez-skill.git
+[submodule "roomba-serial-command-skill"]
+	path = roomba-serial-command-skill
+	url = https://github.com/JonStratton/roomba-serial-command-skill


### PR DESCRIPTION
**Name of your skill**: roomba-serial-command-skill

## Description:

This skill is to be used with a roomba with a serial connection to a small single board computer running the roomba-serial-command-service. This device must also be connected to the same local network that mycroft is running from. The mycoft skill will use zeroconf to try to locate the service.

## Checklist:
  - [X ] Used [Meta Editor](http://rawgit.com/MycroftAI/mycroft-skills/master/meta_editor.html) to generate the skill README
  - [X ] Skill has been tested and works 
  - [X ] Read and verified approval process - https://mycroft.ai/documentation/skills/skills-acceptance-process (Can require a community member vouching for skill)
  - [X ] .gitmodules has been updated with the following:
  
```
+[submodule "NAME OF YOUR SKILL"]
+	path = name-of-your-skill
+	url = URL.FOR.YOUR.SKILL.git
```
