### PR TITLE
Add fallback-query

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -193,3 +193,6 @@
 [submodule "pick-number"]
 	path = pick-number
 	url = https://github.com/pcwii/skill-pick-number.git
+[submodule "fallback-query"]
+	path = fallback-query
+	url = https://github.com/MycroftAI/skill-query.git


### PR DESCRIPTION

## Info

This PR adds the new skill, [fallback-query](https://github.com/MycroftAI/skill-query), to the skills repo.

## Description


Negotiates handling of questions by calling all registered Common Query Skills. This is done by sending a `question:query` message with the utterance to give the skills the posibility to report back if they can answer the question and at which confidence.


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.12</sub>