### PR TITLE
Add fallback-recommendations-skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -202,3 +202,6 @@
 [submodule "mycroft-wink-iot"]
 	path = mycroft-wink-iot
 	url = https://github.com/MycroftAI/skill-wink-iot.git
+[submodule "fallback-recommendations-skill"]
+	path = fallback-recommendations-skill
+	url = https://github.com/linuss1/fallback-recommendations-skill.git


### PR DESCRIPTION

## Info

This PR adds the new skill, [fallback-recommendations-skill](https://github.com/LinusS1/fallback-recommendations-skill), to the skills repo.

## Description


When Mycroft doesn't know something, this fallback skill will look up skills from the Marketplace that could help you complete your request. If it finds an appropriate skill, this will be downloaded to your device.


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.12</sub>