### PR TITLE
Add mycroft-wink-iot

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -199,3 +199,6 @@
 [submodule "iss-tracker"]
 	path = iss-tracker
 	url = https://github.com/andlo/iss-tracker-skill.git
+[submodule "mycroft-wink-iot"]
+	path = mycroft-wink-iot
+	url = https://github.com/MycroftAI/skill-wink-iot.git


### PR DESCRIPTION

## Info

This PR adds the new skill, [mycroft-wink-iot](https://github.com/MycroftAI/skill-wink-iot), to the skills repo.

## Description


Interact with your smart home using the [Wink system](https://www.wink.com/).  Wink hubs can work with virtually any brand of lights, including [Philips Hue](https://www2.meethue.com/en-us), [GE](https://www.gelighting.com/), [Sylvania](https://www.sylvania.com/en-us/Pages/default.aspx), [Cree](https://creebulb.com/connected), and many more.  Use Mycroft to easily interact with nearby lights and light groups you create within the Wink ecosystem.

Your can easily find the right light or lights based on the names of lights and groups.  The Mycroft device's Name (set at [Home](https://home.mycroft.ai/ -- check by asking "what is your name?")
can be used to find lights and/or groups with begin with that same name. For example, if your Mycroft device's location is set to 'Kitchen' and you say "Turn on the light", lights with the following names would be turned on:

* Kitchen
* Kitchen sink
* Kitchen fan (group consisting of 'Fan 1', 'Fan 2', 'Fan 3')
It will NOT turn on a light called "Porch off the kitchen".

You can also include the light/group name in your request, along with intensity words, such as: `bright`, `dim`, `full`, `half`, `completely`, `partially`


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.12</sub>