### PR TITLE
Add testing-dice

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -202,3 +202,6 @@
 [submodule "mycroft-wink-iot"]
 	path = mycroft-wink-iot
 	url = https://github.com/MycroftAI/skill-wink-iot.git
+[submodule "testing-dice"]
+	path = testing-dice
+	url = https://github.com/forslund/dice-skill.git


### PR DESCRIPTION

## Info

This PR adds the new skill, [testing-dice](https://github.com/forslund/dice-skill), to the skills repo.

## Description


This skill enables mycroft to generate random numbers for you.
You either need to specify a range or type of dice (e.g. d20).

Perfect whenever you need to generate a random number, but don't have a dice nearby.


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.12</sub>