### PR TITLE
Add magic-mirror-voice-control

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -208,3 +208,6 @@
 [submodule "carstena-the-cows-lists"]
 	path = carstena-the-cows-lists
 	url = https://github.com/CarstenAgerskov/skill-the-cows-lists.git
+[submodule "magic-mirror-voice-control"]
+	path = magic-mirror-voice-control
+	url = https://github.com/dmwilsonkc/magic-mirror-voice-control-skill.git


### PR DESCRIPTION

## Info

This PR adds the new skill, [magic-mirror-voice-control](https://github.com/dmwilsonkc/magic-mirror-voice-control-skill), to the skills repo.

## Description


This mycroft skill passes commands to an accessible MagicMirror installed anywhere on the same network as Mycroft. It requires a working install of [MagicMirror](https://github.com/MichMich/MagicMirror) and the [MMM-Remote-Control module](https://github.com/Jopyth/MMM-Remote-Control). It must be installed AND ACCESSIBLE ON THE SAME NETWORK AS MYCROFT.

This skill requires MMM-Remote-Control be installed and working properly on the MagicMirror.

You must configure the MagicMirror's config.js file to properly whitelist the ip address of your Mycroft.

In the MagicMirror's config.js:

Replace: address: "localhost", With: address: "0.0.0.0", and

Replace: ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"], with ipWhitelist: ["127.0.0.1", "192.168.X.1/24"],

You can use this skill to hide or show modules, update the mirror or individual modules,
refresh or restart the mirror, list installed modules, install modules by name (will still require you
to configure the MagicMirror config.js by SSH or VNC for the particular skill you install), change pages of modules by either swipe commands or telling mycroft to "go to page [number]"(requires that [MMM-pages](https://github.com/edward-shen/MMM-pages) be installed), restart or reboot the Raspberry Pi.


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.12</sub>