### PR TITLE
Add calendar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -217,3 +217,6 @@
 [submodule "Gui-Examples"]
 	path = Gui-Examples
 	url = https://github.com/AIIX/Skill-Gui-Examples
+[submodule "calendar"]
+	path = calendar
+	url = https://github.com/linuss1/calendar-skill


### PR DESCRIPTION

## Info

This PR adds the new skill, [calendar](https://github.com/LinusS1/calendar-skill), to the skills repo.

## Description


With this skill, you can access your iCal server, or just use a [local calendar on your device](https://bit.ly/mycroft-calendar-ics), that doesn't sync anywhere. This skill needs configuration if your use an iCal server. You can (if you're technical) use a local file and not store your server credentials with Mycroft Home, if you follow the instructions [here](https://bit.ly/mycroft-calendar-local).


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.13</sub>