### PR TITLE
Add today-in-history

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -229,3 +229,6 @@
 [submodule "nevermind-skill"]
 	path = nevermind-skill
 	url = https://github.com/ChanceNCounter/nevermind-skill
+[submodule "today-in-history"]
+	path = today-in-history
+	url = https://github.com/austin-carnahan/days-in-history-skill


### PR DESCRIPTION

## Info

This PR adds the new skill, [today-in-history](https://github.com/austin-carnahan/days-in-history-skill), to the skills repo.

## Description


Provides historical events for today or any other calendar day using information pulled from [Wikipedia](https://www.wikipedia.org).

This Skill uses the [Wikimedia API](https://en.wikipedia.org/w/api.php).


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.13</sub>