### PR TITLE
Add days-in-history

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -226,3 +226,6 @@
 [submodule "Wiktionary"]
 	path = Wiktionary
 	url = https://github.com/TREE-Ind/Wiktionary-Skill
+[submodule "days-in-history"]
+	path = days-in-history
+	url = https://github.com/austin-carnahan/days-in-history-skill


### PR DESCRIPTION

## Info

This PR adds the new skill, [days-in-history](https://github.com/austin-carnahan/days-in-history-skill), to the skills repo.

## Description


Provides historical events for today or any other calendar day using information pulled from [Wikipedia](https://www.wikipedia.org).

This Skill uses the [Wikimedia API](https://en.wikipedia.org/w/api.php).


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.13</sub>