### PR TITLE
Add google-calendar-skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -235,3 +235,6 @@
 [submodule "dismissal-skill"]
 	path = dismissal-skill
 	url = https://github.com/ChanceNCounter/dismissal-skill.git
+[submodule "google-calendar-skill"]
+	path = google-calendar-skill
+	url = https://github.com/forslund/gcalendar_skill


### PR DESCRIPTION

## Info

This PR adds the new skill, [google-calendar-skill](https://github.com/forslund/gcalendar_skill), to the skills repo.

## Description


Fetches scheduled events from Google Calendar and allows adding events to your calendar.


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.13</sub>