### PR TITLE
Add web-terminal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -232,3 +232,6 @@
 [submodule "fallback-recommendations-skill"]
 	path = fallback-recommendations-skill
 	url = https://github.com/linuss1/fallback-recommendations-skill
+[submodule "web-terminal"]
+	path = web-terminal
+	url = https://github.com/andlo/web-terminal-skill


### PR DESCRIPTION

## Info

This PR adds the new skill, [web-terminal](https://github.com/andlo/web-terminal-skill), to the skills repo.

## Description


This skill installs and run a web terminal and/or a web CLI client.

After install there should be a running web CLI client wich you can acces from a browser on
http://device:8080 where device is the hostname of your mycroft device.

Yo can start at terminal by saying "hey mycroft - run web terminal". Then there will be a full
shell running wich you can access from a browser on http://device:8022 where device is the
hostname of your mycroft device.

On settings on home.mycroft.ai you can change ports and set if CLI and/or Terminal should auto start or not.

The skill uses the ttyd from Shuanglei Tao - https://github.com/tsl0922/ttyd


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.14</sub>