### PR TITLE
Add end-listening-sound

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -232,3 +232,6 @@
 [submodule "fallback-recommendations-skill"]
 	path = fallback-recommendations-skill
 	url = https://github.com/linuss1/fallback-recommendations-skill
+[submodule "end-listening-sound"]
+	path = end-listening-sound
+	url = https://github.com/krisgesling/end-listening-sound-skill


### PR DESCRIPTION

## Info

This PR adds the new skill, [end-listening-sound](https://github.com/krisgesling/end-listening-sound-skill), to the skills repo.

## Description


This enables support for the `end_listening` configuration parameter, playing a sound at the end of the microphone recording.

By default it will attempt to play the file: `mycroft-core/mycroft/res/snd/end_listening.wav`. If the file isn't found it will play the standard `acknowledge.mp3`.


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.14</sub>