### PR TITLE
Add remote-debug

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -232,3 +232,6 @@
 [submodule "fallback-recommendations-skill"]
 	path = fallback-recommendations-skill
 	url = https://github.com/linuss1/fallback-recommendations-skill
+[submodule "remote-debug"]
+	path = remote-debug
+	url = https://github.com/andlo/remote-debug-skill


### PR DESCRIPTION

## Info

This PR adds the new skill, [remote-debug](https://github.com/andlo/remote-debug-skill), to the skills repo.

## Description


This skill adds PTVSD - Python Tools for Visual Studio debug server to make it posible to
debug running skills.
It is made as a companion to the THEIA IDE skill to enable debugging from there. But if you
use another IDE like VS Code you can use this skill to inject the debug adaptor in the
mycroft.skills service and attach to it on port 5678.

When you activate debugging by saying "Run debug adaptor" the skill will change Settings for
padatious single_thread = true so skills service runs in single thread.

THEIA IDE is already setup so you just have to start debug from debug menu

When finish debugging say "End debug adaptor" and skill restore single_thread settings and
restart mycroft.skills service

[https://github.com/Microsoft/ptvsd](https://github.com/Microsoft/ptvsd)


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.14</sub>