### PR TITLE
Add web-launcher

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -232,3 +232,6 @@
 [submodule "myepisodes"]
 	path = myepisodes
 	url = https://github.com/brezuicabogdan/myepisodes-skill
+[submodule "web-launcher"]
+	path = web-launcher
+	url = https://github.com/krisgesling/web-launcher-skill


### PR DESCRIPTION

## Info

This PR adds the new skill, [web-launcher](https://github.com/krisgesling/web-launcher-skill), to the skills repo.

## Description


A simple Skill to open web pages in your default browser.

Currently Sites must be included in the `sites.value` file, or added to the Skill settings as a custom url.

Contributions to this list are welcomed, as are suggestions for better ways to translate natural language into the correct url.


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.15</sub>