### PR TITLE
Update base docker image to 20.08

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV GITHUB_API_KEY=$github_api_key
 RUN msm update
 # Load updated test cases for default skills
 RUN python -m test.integrationtests.voight_kampff.test_setup \
-    --config default.yml \
+    --config test/integrationtests/voight_kampff/default.yml \
     --platform $platform
 WORKDIR /opt/mycroft/mycroft-core
 COPY test-requirements.txt skill-test-requirements.txt
@@ -31,5 +31,10 @@ RUN python -m test.integrationtests.voight_kampff.test_setup \
     --platform $platform \
     --branch $branch_name \
     --repo-url $repo_url
+
+RUN mkdir /etc/mycroft || true
+RUN echo '{"tts": {"module": "dummy"}}' > /etc/mycroft/mycroft.conf
+ENV PYTHONPATH /opt/mycroft/mycroft-core/
 # Set working directory for testing
 WORKDIR /opt/mycroft/mycroft-core/test/integrationtests/voight_kampff
+ENTRYPOINT ["./run_test_suite.sh"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
                 sh 'git remote add mine git+ssh://git@github.com/forslund/mycroft-skills.git || true'
                 sh 'git push -uf mine ${BRANCH_NAME}'
                 sh 'docker build \
-                    --build-arg major_release=20.02 \
+                    --build-arg major_release=20.08 \
                     --build-arg platform=mycroft_mark_1 \
                     --build-arg pull_request=$BRANCH_NAME \
                     --build-arg branch_name=$BRANCH_NAME \


### PR DESCRIPTION
This updates the Jenkinsfile to use the 20,08 docker base container for the tests. Currently the PR's seem to be built with the 20.02 version of Mycroft-core.

After checking the build logs on Hudson I'm not entirely sure the release triggered the container build process as intended...I guess we'll see from this PR :)