### PR TITLE
Add support for MycroftOS - Default skills

### DIFF
--- a/DEFAULT-SKILLS.MycroftOS
+++ b/DEFAULT-SKILLS.MycroftOS
@@ -1,0 +1,37 @@
+# MycroftOS specific skills
+#skill-mycroftos-gui
+#skill-mycroftos-enclosure
+
+# Core skills
+#skill-wifi-connect
+mycroft-pairing
+mycroft-configuration
+mycroft-installer
+mycroft-stop
+mycroft-naptime
+mycroft-playback-control
+mycroft-speak
+mycroft-volume
+fallback-query
+
+# Common skills
+mycroft-fallback-duck-duck-go
+fallback-wolfram-alpha
+fallback-unknown
+mycroft-alarm
+mycroft-audio-record
+mycroft-date-time
+mycroft-hello-world
+mycroft-ip
+mycroft-joke
+mycroft-npr-news
+mycroft-personal
+mycroft-reminder
+mycroft-singing
+mycroft-spelling
+mycroft-stock
+mycroft-support-helper
+mycroft-timer
+mycroft-weather
+mycroft-wiki
+mycroft-version-checker


### PR DESCRIPTION
**Name of your skill**: DEFAULT SKILLS for MycroftOS
## Description:

For MycroftOS I have set the platform to well...  "MycroftOS"

At the moment this is just a copy and paste from the Mark 2 default skills list, however will soon be adjusted with some specific skills. Would like to merge this as it will remove a lot of INFO log messages about it.

It has NO impact what so ever on any other things within the repo. Hope this can be accepted and merged.