### PR TITLE
Add openhab-connect-skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -229,3 +229,6 @@
 [submodule "myepisodes"]
 	path = myepisodes
 	url = https://github.com/brezuicabogdan/myepisodes-skill
+[submodule "openhab-connect-skill"]
+	path = openhab-connect-skill
+	url = https://github.com/Humple/openhab-connect-skill


### PR DESCRIPTION

## Info

This PR adds the new skill, [openhab-connect-skill](https://github.com/Humple/openhab-connect-skill), to the skills repo.

## Description


The skill can be used to control the openhab devices


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.16</sub>