### PR TITLE
Add severe-weather-information

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -229,3 +229,6 @@
 [submodule "myepisodes"]
 	path = myepisodes
 	url = https://github.com/brezuicabogdan/myepisodes-skill
+[submodule "severe-weather-information"]
+	path = severe-weather-information
+	url = https://github.com/domcross/severe-weather-information-skill


### PR DESCRIPTION

## Info

This PR adds the new skill, [severe-weather-information](https://github.com/domcross/severe-weather-information-skill), to the skills repo.

## Description


The severe weather information skills can connect to many weather alerting services (as long as they are implementing the [Common Alert Protocol](https://en.wikipedia.org/wiki/Common_Alerting_Protocol))

Among them many from following lists:

[severe weather information center](https://severeweather.wmo.int/v2/sources.html)

[alerting world weather](https://alerting.worldweather.org/)

[meteoalarm](http://meteoalarm.eu/)

After installation go to home.mycroft.ai and select your preferred weather service from the list on the skills configuration page.

Ask "are there weather alerts?" to check for new alerts.

You can also set a "watchdog" that automatically checks for new alerts and notifies you...


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.16</sub>