### PR TITLE
Add wake-button-rpi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -229,3 +229,6 @@
 [submodule "myepisodes"]
 	path = myepisodes
 	url = https://github.com/brezuicabogdan/myepisodes-skill
+[submodule "wake-button-rpi"]
+	path = wake-button-rpi
+	url = https://github.com/guhl/wake-button-rpi-skill


### PR DESCRIPTION

## Info

This PR adds the new skill, [wake-button-rpi](https://github.com/guhl/wake-button-rpi-skill), to the skills repo.

## Description


Press a button that is connected to a GPIO input to trigger wakeup so that the device starts listening.
If the button is pressed for a longer time he stops whatever he is doing.
This skill is heavily based on the Google AIY voicekit skill by Andlo.


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.15</sub>