### PR TITLE
Prevent simultaneous jobs writing to same directory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,10 +47,11 @@ pipeline {
                 timeout(time: 60, unit: 'MINUTES')
                 {
                     sh 'mkdir -p $HOME/allure/skills/$BRANCH_ALIAS'
+                    sh 'mkdir -p $HOME/mycroft-logs/skills/$BRANCH_ALIAS'
                     sh 'docker run \
                         --volume "$HOME/voight-kampff/identity:/root/.mycroft/identity" \
                         --volume "$HOME/allure/skills/$BRANCH_ALIAS:/root/allure" \
-                        --volume "$HOME/mycroft-logs:/var/log/mycroft" \
+                        --volume "$HOME/mycroft-logs/skills/$BRANCH_ALIAS:/var/log/mycroft" \
                         --label build=${BUILD_TAG} \
                         voight-kampff-skill:${BRANCH_ALIAS} \
                         -f allure_behave.formatter:AllureFormatter \
@@ -70,7 +71,7 @@ pipeline {
                         -R /root/allure/"'
                     echo 'Changing ownership of Mycroft logs...'
                     sh 'docker run \
-                        --volume "$HOME/mycroft-logs:/var/log/mycroft" \
+                        --volume "$HOME/mycroft-logs/skills/$BRANCH_ALIAS:/var/log/mycroft" \
                         --entrypoint=/bin/bash \
                         --label build=${BUILD_TAG} \
                         voight-kampff-skill:${BRANCH_ALIAS} \
@@ -92,8 +93,8 @@ pipeline {
                         ])
                     }
                     unarchive mapping:['allure-report.zip': 'allure-report.zip']
-                    sh 'zip mycroft-logs.zip -r $HOME/mycroft-logs'
-                    sh 'rm $HOME/mycroft-logs/*'
+                    sh 'zip mycroft-logs.zip -r $HOME/mycroft-logs/skills/$BRANCH_ALIAS'
+                    sh 'rm -r $HOME/mycroft-logs/skills/$BRANCH_ALIAS'
                     sh (
                         label: 'Publish Report to Web Server',
                         script: '''scp allure-report.zip root@157.245.127.234:~;

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,12 +46,12 @@ pipeline {
                 echo 'Running Tests'
                 timeout(time: 60, unit: 'MINUTES')
                 {
-                    sh 'mkdir -p $HOME/allure/skills/$BRANCH_ALIAS'
-                    sh 'mkdir -p $HOME/mycroft-logs/skills/$BRANCH_ALIAS'
+                    sh 'mkdir -p $HOME/skills/$BRANCH_ALIAS/allure'
+                    sh 'mkdir -p $HOME/skills/$BRANCH_ALIAS/mycroft-logs'
                     sh 'docker run \
                         --volume "$HOME/voight-kampff/identity:/root/.mycroft/identity" \
-                        --volume "$HOME/allure/skills/$BRANCH_ALIAS:/root/allure" \
-                        --volume "$HOME/mycroft-logs/skills/$BRANCH_ALIAS:/var/log/mycroft" \
+                        --volume "$HOME/skills/$BRANCH_ALIAS/allure:/root/allure" \
+                        --volume "$HOME/skills/$BRANCH_ALIAS/mycroft-logs:/var/log/mycroft" \
                         --label build=${JOB_NAME} \
                         voight-kampff-skill:${BRANCH_ALIAS} \
                         -f allure_behave.formatter:AllureFormatter \
@@ -63,7 +63,7 @@ pipeline {
                     echo 'Report Test Results'
                     echo 'Changing ownership of allure results...'
                     sh 'docker run \
-                        --volume "$HOME/allure/skills/$BRANCH_ALIAS:/root/allure" \
+                        --volume "$HOME/skills/$BRANCH_ALIAS/allure:/root/allure" \
                         --entrypoint=/bin/bash \
                         --label build=${JOB_NAME} \
                         voight-kampff-skill:${BRANCH_ALIAS} \
@@ -71,7 +71,7 @@ pipeline {
                         -R /root/allure/"'
                     echo 'Changing ownership of Mycroft logs...'
                     sh 'docker run \
-                        --volume "$HOME/mycroft-logs/skills/$BRANCH_ALIAS:/var/log/mycroft" \
+                        --volume "$HOME/skills/$BRANCH_ALIAS/mycroft-logs:/var/log/mycroft" \
                         --entrypoint=/bin/bash \
                         --label build=${JOB_NAME} \
                         voight-kampff-skill:${BRANCH_ALIAS} \
@@ -80,9 +80,9 @@ pipeline {
 
                     echo 'Transferring...'
                     sh 'rm -rf allure-result/*'
-                    sh 'mv $HOME/allure/skills/$BRANCH_ALIAS/allure-result allure-result'
+                    sh 'mv $HOME/skills/$BRANCH_ALIAS/allure/allure-result allure-result'
                     // This directory should now be empty, rmdir will intentionally fail if not.
-                    sh 'rmdir $HOME/allure/skills/$BRANCH_ALIAS'
+                    sh 'rmdir $HOME/skills/$BRANCH_ALIAS/allure'
                     script {
                         allure([
                             includeProperties: false,
@@ -93,8 +93,10 @@ pipeline {
                         ])
                     }
                     unarchive mapping:['allure-report.zip': 'allure-report.zip']
-                    sh 'zip mycroft-logs.zip -r $HOME/mycroft-logs/skills/$BRANCH_ALIAS'
-                    sh 'rm -r $HOME/mycroft-logs/skills/$BRANCH_ALIAS'
+                    sh 'zip mycroft-logs.zip -r $HOME/skills/$BRANCH_ALIAS/mycroft-logs'
+                    sh 'rm -r $HOME/skills/$BRANCH_ALIAS/mycroft-logs'
+                    // This directory should now be empty, rmdir will intentionally fail if not.
+                    sh 'rmdir $HOME/skills/$BRANCH_ALIAS'
                     sh (
                         label: 'Publish Report to Web Server',
                         script: '''scp allure-report.zip root@157.245.127.234:~;

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ pipeline {
                             ssh root@157.245.127.234 "rm -rf /var/www/voight-kampff/skills/${BRANCH_ALIAS}";
                             ssh root@157.245.127.234 "mv allure-report /var/www/voight-kampff/skills/${BRANCH_ALIAS}"
                             scp mycroft-logs.zip root@157.245.127.234:~;
-                            ssh root@157.245.127.234 "mkdir -p /var/www/voight-kampff/core/${BRANCH_ALIAS}/logs"
+                            ssh root@157.245.127.234 "mkdir -p /var/www/voight-kampff/skills/${BRANCH_ALIAS}/logs"
                             ssh root@157.245.127.234 "unzip -oj ~/mycroft-logs.zip -d /var/www/voight-kampff/skills/${BRANCH_ALIAS}/logs/";
                         '''
                     )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ pipeline {
                     }
                     unarchive mapping:['allure-report.zip': 'allure-report.zip']
                     sh 'zip mycroft-logs.zip -r $HOME/skills/$BRANCH_ALIAS/mycroft-logs'
-                    sh 'rm -r $HOME/skills/$BRANCH_ALIAS/mycroft-logs'
+                    sh 'rm -rf $HOME/skills/$BRANCH_ALIAS/mycroft-logs'
                     // This directory should now be empty, rmdir will intentionally fail if not.
                     sh 'rmdir $HOME/skills/$BRANCH_ALIAS'
                     sh (

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,9 @@ pipeline {
                     changeRequest()
                 }
             }
+            options {
+                lock(resource: "lock_${env.JOB_NAME}")
+            }
             environment {
                 //spawns GITHUB_USR and GITHUB_PSW environment variables
                 GITHUB=credentials('38b2e4a6-167a-40b2-be6f-d69be42c8190')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
                     --build-arg repo_url=https://github.com/forslund/mycroft-skills \
                     --build-arg github_api_key=$GITHUB_PSW \
                     --no-cache \
-                    --label build=${BUILD_TAG} \
+                    --label build=${JOB_NAME} \
                     -t voight-kampff-skill:${BRANCH_ALIAS} .'
                 echo 'Running Tests'
                 timeout(time: 60, unit: 'MINUTES')
@@ -52,7 +52,7 @@ pipeline {
                         --volume "$HOME/voight-kampff/identity:/root/.mycroft/identity" \
                         --volume "$HOME/allure/skills/$BRANCH_ALIAS:/root/allure" \
                         --volume "$HOME/mycroft-logs/skills/$BRANCH_ALIAS:/var/log/mycroft" \
-                        --label build=${BUILD_TAG} \
+                        --label build=${JOB_NAME} \
                         voight-kampff-skill:${BRANCH_ALIAS} \
                         -f allure_behave.formatter:AllureFormatter \
                         -o /root/allure/allure-result --tags ~@xfail'
@@ -65,7 +65,7 @@ pipeline {
                     sh 'docker run \
                         --volume "$HOME/allure/skills/$BRANCH_ALIAS:/root/allure" \
                         --entrypoint=/bin/bash \
-                        --label build=${BUILD_TAG} \
+                        --label build=${JOB_NAME} \
                         voight-kampff-skill:${BRANCH_ALIAS} \
                         -x -c "chown $(id -u $USER):$(id -g $USER) \
                         -R /root/allure/"'
@@ -73,7 +73,7 @@ pipeline {
                     sh 'docker run \
                         --volume "$HOME/mycroft-logs/skills/$BRANCH_ALIAS:/var/log/mycroft" \
                         --entrypoint=/bin/bash \
-                        --label build=${BUILD_TAG} \
+                        --label build=${JOB_NAME} \
                         voight-kampff-skill:${BRANCH_ALIAS} \
                         -x -c "chown $(id -u $USER):$(id -g $USER) \
                         -R /var/log/mycroft/"'
@@ -224,7 +224,7 @@ pipeline {
             sh(
                 label: 'Delete Docker Image on Success',
                 script: '''
-                    docker image prune --all --force --filter label=build=${BUILD_TAG};
+                    docker image prune --all --force --filter label=build=${JOB_NAME};
                 '''
             )
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,9 +42,10 @@ pipeline {
                 echo 'Running Tests'
                 timeout(time: 60, unit: 'MINUTES')
                 {
+                    sh 'mkdir -p $HOME/allure/skills/$BRANCH_ALIAS'
                     sh 'docker run \
                         --volume "$HOME/voight-kampff/identity:/root/.mycroft/identity" \
-                        --volume "$HOME/allure/skills/:/root/allure" \
+                        --volume "$HOME/allure/skills/$BRANCH_ALIAS:/root/allure" \
                         --volume "$HOME/mycroft-logs:/var/log/mycroft" \
                         voight-kampff-skill:${BRANCH_ALIAS} \
                         -f allure_behave.formatter:AllureFormatter \
@@ -56,7 +57,7 @@ pipeline {
                     echo 'Report Test Results'
                     echo 'Changing ownership of allure results...'
                     sh 'docker run \
-                        --volume "$HOME/allure/skills/:/root/allure" \
+                        --volume "$HOME/allure/skills/$BRANCH_ALIAS:/root/allure" \
                         --entrypoint=/bin/bash \
                         voight-kampff-skill:${BRANCH_ALIAS} \
                         -x -c "chown $(id -u $USER):$(id -g $USER) \
@@ -71,7 +72,9 @@ pipeline {
 
                     echo 'Transferring...'
                     sh 'rm -rf allure-result/*'
-                    sh 'mv $HOME/allure/skills/allure-result allure-result'
+                    sh 'mv $HOME/allure/skills/$BRANCH_ALIAS/allure-result allure-result'
+                    // This directory should now be empty, rmdir will intentionally fail if not.
+                    sh 'rmdir $HOME/allure/skills/$BRANCH_ALIAS'
                     script {
                         allure([
                             includeProperties: false,


### PR DESCRIPTION
## Description:

When multiple Skills run Voight Kampff tests simultaneously they are currently writing the allure data to the same directory on the host. This can create conflicts particularly when the first job cleans up, it wipes out the second jobs data.

This resolves the issue by:
- creating unique directories for each PR under a directory for this repository. 
  It seems like refactoring the file locations could be useful in a follow up PR to bring all outputs for a job into a single directory eg `$HOME/mycroft-skills/PR-####/(allure|mycroft-logs)`
- adds a lockable resource with the repo and PR number to ensure that the directory won't be used by another job from the same PR. I don't think this can happen anyway, but it seemed like an easy fail safe.

Finally we improved the cleanup of docker containers by explicitly removing containers generated by this job if the build was successful. Based on: https://github.com/MycroftAI/selene-backend/pull/230