### PR TITLE
Use unique paths for temporary allure-report storage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,10 +99,14 @@ pipeline {
                     sh 'rmdir $HOME/skills/$BRANCH_ALIAS'
                     sh (
                         label: 'Publish Report to Web Server',
-                        script: '''scp allure-report.zip root@157.245.127.234:~;
-                            ssh root@157.245.127.234 "unzip -o ~/allure-report.zip";
+                        script: '''
+                            ssh root@157.245.127.234 "mkdir -p ~/allure-reports/skills/${BRANCH_ALIAS}";
+                            scp allure-report.zip root@157.245.127.234:~/allure-reports/skills/${BRANCH_ALIAS}/;
+                            ssh root@157.245.127.234 "unzip -o ~/allure-reports/skills/${BRANCH_ALIAS}/allure-report.zip -d ~/allure-reports/skills/${BRANCH_ALIAS}/";
                             ssh root@157.245.127.234 "rm -rf /var/www/voight-kampff/skills/${BRANCH_ALIAS}";
-                            ssh root@157.245.127.234 "mv allure-report /var/www/voight-kampff/skills/${BRANCH_ALIAS}"
+                            ssh root@157.245.127.234 "mv ~/allure-reports/skills/${BRANCH_ALIAS}/allure-report /var/www/voight-kampff/skills/${BRANCH_ALIAS}"
+                            ssh root@157.245.127.234 "rm ~/allure-reports/skills/${BRANCH_ALIAS}/allure-report.zip";
+                            ssh root@157.245.127.234 "rmdir ~/allure-reports/skills/${BRANCH_ALIAS}";
                             scp mycroft-logs.zip root@157.245.127.234:~;
                             ssh root@157.245.127.234 "mkdir -p /var/www/voight-kampff/skills/${BRANCH_ALIAS}/logs"
                             ssh root@157.245.127.234 "unzip -oj ~/mycroft-logs.zip -d /var/www/voight-kampff/skills/${BRANCH_ALIAS}/logs/";


### PR DESCRIPTION
When transferring allure-report.zip it was being stored in a common location on the web host. If multiple jobs were running, they could interfere or delete that output before it had been fully extracted and moved.

Once this PR is accepted, we can do the same for mycroft-core as it also uses the same file path.

#### How to test

I've replayed the job using this modified Jenkinsfile on PR #1515.