### PR TITLE
Add homescreen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -232,3 +232,6 @@
 [submodule "camera"]
 	path = camera
 	url = https://github.com/MycroftAI/skill-camera
+[submodule "homescreen"]
+	path = homescreen
+	url = https://github.com/MycroftAI/skill-homescreen


### PR DESCRIPTION

## Info

This PR adds the new skill, [homescreen](https://github.com/MycroftAI/skill-homescreen), to the skills repo.

## Description


Homescreen provides a default display for Mycroft devices with a rich display such as the Mark II.

By default, the current time and date will be shown. Additional widgets can be activated to display other content such as the current weather.

The wallpaper may be changed randomly or a custom image can be defined in the Skill settings.


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.16</sub>