### PR TITLE
Handle skill name and submodule mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-
 *.xml
 *.iml
+
+# Generated files
+test_skill.yml
+

--- a/build_test_config.py
+++ b/build_test_config.py
@@ -61,7 +61,7 @@ def get_skill_author(skill_submodule_name):
     """Get the author of the Skill repo associated with the submodule."""
     with open('.gitmodules') as f:
         for line in f:
-            if line.strip() == f'[submodule "{skill_submodule_name}"]':
+            if line.strip() == f'path = {skill_submodule_name}':
                 # The submodule definition consists of 3 lines:
                 # [submodule "camera"]
                 # 	path = camera
@@ -69,7 +69,6 @@ def get_skill_author(skill_submodule_name):
                 break
         else:
             raise Exception(f'{skill_submodule_name} not found')
-        f.readline()  # Skip past the path line
         skill_url = f.readline().split(' = ')[1]
         skill_author = skill_url.split('/')[3]
         return skill_author


### PR DESCRIPTION
Handle the case where the skill name and submodule path is different. If I'm reading the code correctly the `skill_submodule_name` seems to be the path and not the name. This changes the code to look at the path, perhaps a name change of the variable is in order as well?