### PR TITLE
Fix finding Skill author

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-
 *.xml
 *.iml
+
+# Generated files
+test_skill.yml
+

--- a/build_test_config.py
+++ b/build_test_config.py
@@ -61,7 +61,7 @@ def get_skill_author(skill_submodule_name):
     """Get the author of the Skill repo associated with the submodule."""
     with open('.gitmodules') as f:
         for line in f:
-            if line.strip() == f'[submodule "{skill_submodule_name}"]':
+            if line.strip() == f'path = {skill_submodule_name}':
                 # The submodule definition consists of 3 lines:
                 # [submodule "camera"]
                 # 	path = camera
@@ -69,7 +69,6 @@ def get_skill_author(skill_submodule_name):
                 break
         else:
             raise Exception(f'{skill_submodule_name} not found')
-        f.readline()  # Skip past the path line
         skill_url = f.readline().split(' = ')[1]
         skill_author = skill_url.split('/')[3]
         return skill_author

--- a/build_test_config.py
+++ b/build_test_config.py
@@ -86,17 +86,8 @@ def get_skill_author(skill_submodule_path, pull_request_diff):
     return skill_author
 
 
-def write_test_config_file(skill_submodule_path, skill_author):
-    """Write a YAML file for the integration test setup script
-
-    Not every PR into this repository will be a change to a skill.  If no
-    skill submodule was found in the PR, just add the "hello world" skill.
-    """
-    if skill_submodule_path is None:
-        submodule = 'skill-hello-world'
-        skill_author = 'MycroftAI'
-    else:
-        submodule = skill_submodule_path
+def write_test_config_file(submodule, skill_author):
+    """Write a YAML file for the integration test setup script."""
     with open('test_skill.yml', 'w') as config_file:
         config_file.write('test_skills:\n')
         config_file.write(' '.join(['-', submodule, '-u', skill_author, '\n']))
@@ -106,7 +97,13 @@ def main():
     args = parse_command_line()
     pull_request_diff = get_pull_request_diff(args)
     skill_submodule_path = get_pull_request_submodule(pull_request_diff)
-    skill_author = get_skill_author(skill_submodule_path, pull_request_diff)
+    if skill_submodule_path is None:
+        # Not every PR into this repository will be a change to a skill. 
+        # If no Skill submodule was found, use the "hello world" Skill.
+        skill_submodule_path = 'skill-hello-world'
+        skill_author = 'MycroftAI'
+    else:
+        skill_author = get_skill_author(skill_submodule_path, pull_request_diff)
     write_test_config_file(skill_submodule_path, skill_author)
 
 


### PR DESCRIPTION
### Description:
This extends PR #1530 to fix the `get_skill_author` function.

It handles the case where the submodule name and submodule path are different. These are often the same string, but may differ. This changes the code to look at the path, and renames the variable throughout to clarify that.

During testing, I also found that this was failing for PR's that were adding a new Skill such as #1517. I've re-added the previous code that parsed the PR diff. The function now parses the `.gitmodules` file, then if no match has been found parses the PR diff. If both return no results, the existing Exception is raised.

Finally, if no submodule has been added or modified, assume this is a PR to modify mycroft-skills like this one and default to the Hello World Skill.

Replaces #1530 
Fixes #1527

### To test
Run the `build_test_config.py` file against both new and updating PRs. Both should successfully generate a `test_skill.yml` file.

Eg:
```shell
export GITHUB_API_KEY="{YOUR_PERSONAL_KEY}" && python3 build_test_config.py --pull-request=PR-1531
# check test_skill.yml
export GITHUB_API_KEY="{YOUR_PERSONAL_KEY}" && python3 build_test_config.py --pull-request=PR-1517
# check test_skill.yml
```