### PR TITLE
Remove Stock Skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -67,9 +67,6 @@
 [submodule "mycroft-spotify"]
 	path = spotify-skill
 	url = https://github.com/forslund/spotify-skill
-[submodule "mycroft-stock"]
-	path = skill-stock
-	url = https://github.com/mycroftai/skill-stock.git
 [submodule "mycroft-stop"]
 	path = skill-stop
 	url = https://github.com/mycroftai/skill-stop.git

--- a/DEFAULT-SKILLS
+++ b/DEFAULT-SKILLS
@@ -24,7 +24,6 @@ mycroft-personal
 mycroft-reminder
 mycroft-singing
 mycroft-spelling
-mycroft-stock
 mycroft-support-helper
 mycroft-timer
 mycroft-weather

--- a/DEFAULT-SKILLS.kde
+++ b/DEFAULT-SKILLS.kde
@@ -28,7 +28,6 @@ mycroft-personal
 mycroft-reminder
 mycroft-singing
 mycroft-spelling
-mycroft-stock
 mycroft-support-helper
 mycroft-timer
 mycroft-weather

--- a/DEFAULT-SKILLS.mycroft_mark_1
+++ b/DEFAULT-SKILLS.mycroft_mark_1
@@ -30,7 +30,6 @@ mycroft-personal
 mycroft-reminder
 mycroft-singing
 mycroft-spelling
-mycroft-stock
 mycroft-support-helper
 mycroft-timer
 mycroft-weather

--- a/DEFAULT-SKILLS.mycroft_mark_2
+++ b/DEFAULT-SKILLS.mycroft_mark_2
@@ -29,7 +29,6 @@ mycroft-personal
 mycroft-reminder
 mycroft-singing
 mycroft-spelling
-mycroft-stock
 mycroft-support-helper
 mycroft-timer
 mycroft-weather

--- a/DEFAULT-SKILLS.picroft
+++ b/DEFAULT-SKILLS.picroft
@@ -26,7 +26,6 @@ mycroft-personal
 mycroft-reminder
 mycroft-singing
 mycroft-spelling
-mycroft-stock
 mycroft-support-helper
 mycroft-timer
 mycroft-weather


### PR DESCRIPTION
## Description:
The Stock Skill has been deactivated for an extended period waiting for time to implement a new API. Given this is not on our immediate list of priorities, it will be removed as a default Skill and removed from the Marketplace.