### PR TITLE
Use unique path for temp file storage of mycroft-logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,9 +107,12 @@ pipeline {
                             ssh root@157.245.127.234 "mv ~/allure-reports/skills/${BRANCH_ALIAS}/allure-report /var/www/voight-kampff/skills/${BRANCH_ALIAS}"
                             ssh root@157.245.127.234 "rm ~/allure-reports/skills/${BRANCH_ALIAS}/allure-report.zip";
                             ssh root@157.245.127.234 "rmdir ~/allure-reports/skills/${BRANCH_ALIAS}";
-                            scp mycroft-logs.zip root@157.245.127.234:~;
+                            ssh root@157.245.127.234 "mkdir -p ~/mycroft-logs/skills/${BRANCH_ALIAS}";
+                            scp mycroft-logs.zip root@157.245.127.234:~/mycroft-logs/skills/${BRANCH_ALIAS}/;
                             ssh root@157.245.127.234 "mkdir -p /var/www/voight-kampff/skills/${BRANCH_ALIAS}/logs"
-                            ssh root@157.245.127.234 "unzip -oj ~/mycroft-logs.zip -d /var/www/voight-kampff/skills/${BRANCH_ALIAS}/logs/";
+                            ssh root@157.245.127.234 "unzip -oj ~/mycroft-logs/skills/${BRANCH_ALIAS}/mycroft-logs.zip -d /var/www/voight-kampff/skills/${BRANCH_ALIAS}/logs/";
+                            ssh root@157.245.127.234 "rm ~/mycroft-logs/skills/${BRANCH_ALIAS}/mycroft-logs.zip";
+                            ssh root@157.245.127.234 "rmdir ~/mycroft-logs/skills/${BRANCH_ALIAS}";
                         '''
                     )
                     echo 'Report Published'


### PR DESCRIPTION
When transferring the Mycroft logs to the report host, the zip file was being written to a common directory. In the event that multiple jobs were writing to or reading from this directory at the same time, conflicts could occur.

This ensures that the mycroft-logs.zip file is written to a unique path and cleaned up afterward.

This extends the change in #1516.