### PR TITLE
Handle the missing mycroft-stock skill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ARG github_user
 ARG github_api_key
 ENV GITHUB_API_KEY=$github_api_key
 RUN msm update
+# Remove mycroft-stock skill. TODO: Remove in 21.08
+RUN grep --invert-match mycroft-stock default.yml | tee default.yml
 # Load updated test cases for default skills
 RUN python -m test.integrationtests.voight_kampff.test_setup \
     --config default.yml \


### PR DESCRIPTION
Mycroft-stock was removed but exists in the default.yml in mycroft-core version 21.08.0 which is used for the skills test to verify compatibility.

This provides a quick-fix filtering out the offending skill.