### PR TITLE
Extend total test timeout to 100 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
                     --label build=${JOB_NAME} \
                     -t voight-kampff-skill:${BRANCH_ALIAS} .'
                 echo 'Running Tests'
-                timeout(time: 60, unit: 'MINUTES')
+                timeout(time: 100, unit: 'MINUTES')
                 {
                     sh 'mkdir -p $HOME/skills/$BRANCH_ALIAS/allure'
                     sh 'mkdir -p $HOME/skills/$BRANCH_ALIAS/mycroft-logs'


### PR DESCRIPTION
This is to account for the large number of tests being added to Skills. 

This change is not a solution, it only kicks the can a very short distance down the road. However it will allow PR's currently queued to be processed.
