### PR TITLE
Fix #1544 - remove stock skill from test config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG github_api_key
 ENV GITHUB_API_KEY=$github_api_key
 RUN msm update
 # Remove mycroft-stock skill. TODO: Remove in 21.08
-RUN grep --invert-match mycroft-stock default.yml | tee default.yml
+RUN grep --invert-match mycroft-stock default.yml | tee /tmp/default.yml && mv /tmp/default.yml default.yml
 # Load updated test cases for default skills
 RUN python -m test.integrationtests.voight_kampff.test_setup \
     --config default.yml \


### PR DESCRIPTION
#1542 intended to filter out the mycroft-stock skill from the test config. However it was failing to write back to the file that was being grepped, resulting in a blank `default.yml`.

This saves that output to a temporary location as an intermediary step until the grep and writing has completed.