### PR TITLE
Remove Skill author from test definition

### DIFF
--- a/build_test_config.py
+++ b/build_test_config.py
@@ -57,40 +57,11 @@ def get_pull_request_submodule(pull_request_diff):
     return skill_submodule_path
 
 
-def get_skill_author(skill_submodule_path, pull_request_diff):
-    """Get the author of the Skill repo associated with the submodule.
-
-    This first searches the .gitmodules file and then falls back to the diff.
-
-    A submodule definition consists of 3 lines:
-        [submodule "camera"]
-            path = camera
-            url = https://github.com/MycroftAI/skill-camera
-    """
-    skill_url = None
-    with open('.gitmodules') as f:
-        for line in f:
-            if line.strip() == f'path = {skill_submodule_path}':
-                skill_url = f.readline().split(' = ')[1]
-                break
-
-    if skill_url is None:
-        for idx, line in enumerate(pull_request_diff):
-            if line == f'+[submodule "{skill_submodule_path}"]':
-                skill_url = pull_request_diff[idx + 2].split(' = ')[1]
-                break
-        else:
-            raise Exception(f'{skill_submodule_path} not found')
-
-    skill_author = skill_url.split('/')[3]
-    return skill_author
-
-
-def write_test_config_file(submodule, skill_author):
+def write_test_config_file(submodule_path):
     """Write a YAML file for the integration test setup script."""
     with open('test_skill.yml', 'w') as config_file:
         config_file.write('test_skills:\n')
-        config_file.write(' '.join(['-', submodule, '-u', skill_author, '\n']))
+        config_file.write(' '.join(['-', submodule_path, '\n']))
 
 
 def main():
@@ -101,10 +72,7 @@ def main():
         # Not every PR into this repository will be a change to a skill. 
         # If no Skill submodule was found, use the "hello world" Skill.
         skill_submodule_path = 'skill-hello-world'
-        skill_author = 'MycroftAI'
-    else:
-        skill_author = get_skill_author(skill_submodule_path, pull_request_diff)
-    write_test_config_file(skill_submodule_path, skill_author)
+    write_test_config_file(skill_submodule_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The Skill author was added to improve matching of Skills however this is not yet supported by mycroft-core and has actually reduced the confidence level for matches.

#1540 is a good example where the system now struggles to differentiate between "mycroft-mark-1" and "mycroft-mark-2" as the string used to define it is "mycroft-mark-2 -u mycroftai". 

If we wanted to support adding the author in the future, we would need to first update `mycroft-core/test/integrationtests/voight_kampff/test_setup.py`. However I no longer believe that this would be necessary with the current use of submodules.

The second fix in #1520 did not account for the submodule path being used, which is inherently unique. So it is not possible for two Skills to have the same submodule path. As such the first fix preventing characters being accidentally trimmed off the `skill_submodule_path` should be sufficient to have all Skills match exactly.

### To test
1. Generate `test_skill.yml` files using:
  `export GITHUB_API_KEY="{YOUR_KEY}" && python3 build_test_config.py --pull-request=PR-1531`
2. Ensure they are handled correctly by Mycroft-core's test setup script:
  `python -m test.integrationtests.voight_kampff.test_setup --config /path/to/mycroft-skills/test_skill.yml`