### PR TITLE
first run of test_setup.py did not use the updated skills repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ ARG repo_url
 ARG github_user
 ARG github_api_key
 ENV GITHUB_API_KEY=$github_api_key
+RUN msm update
+# Remove mycroft-stock skill. TODO: Remove in 21.08
+RUN grep --invert-match mycroft-stock default.yml | tee /tmp/default.yml && mv /tmp/default.yml default.yml
+# Load updated test cases for default skills...
 # The test_setup.py script was previously executed in the voight-kampff-mark-1 image.
 # Any changes to the naming of feature files will result in both the old and new
 # feature files being executed in the test run.  The short term fix for this is
@@ -16,13 +20,11 @@ ENV GITHUB_API_KEY=$github_api_key
 # test_setup.py script is run again.  The long-term fix is to move the execution of
 # test_setup.py to inside run_test_suite.sh and to add a cleanup step after the tests complete.
 RUN rm /opt/mycroft/mycroft-core/test/integrationtests/voight_kampff/features/*.feature
-RUN msm update
-# Remove mycroft-stock skill. TODO: Remove in 21.08
-RUN grep --invert-match mycroft-stock default.yml | tee /tmp/default.yml && mv /tmp/default.yml default.yml
-# Load updated test cases for default skills
 RUN python -m test.integrationtests.voight_kampff.test_setup \
     --config default.yml \
-    --platform $platform
+    --platform $platform \
+    --branch $branch_name \
+    --repo-url $repo_url
 WORKDIR /opt/mycroft/mycroft-core
 COPY test-requirements.txt skill-test-requirements.txt
 RUN .venv/bin/python -m pip install -r skill-test-requirements.txt


### PR DESCRIPTION
## Description:
Second attempt to fix an issue where a renamed feature file causes the tests for the skill to be run twice.  First attempt removed the feature files added in the core image.  This attempt adds arguments to the test_setup.py execution to pull feature files from the updated skill repository, which contains the new file names.
