### PR TITLE
Add tv-remote-control

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -232,3 +232,6 @@
 [submodule "homescreen"]
 	path = homescreen
 	url = https://github.com/MycroftAI/skill-homescreen
+[submodule "tv-remote-control"]
+	path = tv-remote-control
+	url = https://github.com/devvmh/tv-remote-control-mycroft-skill


### PR DESCRIPTION

## Info

This PR adds the new skill, [tv-remote-control](https://github.com/devvmh/tv-remote-control-skill), to the skills repo.

## Description


This skill defines voice commands for controlling a tv. how this actually works is up to you - you'll need to install lirc or something and then create a shell script or something to actually turn on the tv.


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.16</sub>