### PR TITLE
Add respeaker-mic-array-two-leds-skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -232,3 +232,6 @@
 [submodule "homescreen"]
 	path = homescreen
 	url = https://github.com/MycroftAI/skill-homescreen
+[submodule "respeaker-mic-array-two-leds-skill"]
+	path = respeaker-mic-array-two-leds-skill
+	url = https://github.com/blue1stone/respeaker-mic-array-two-leds-skill


### PR DESCRIPTION

## Info

This PR adds the new skill, [respeaker-mic-array-two-leds-skill](https://github.com/blue1stone/respeaker-mic-array-two-leds-skill), to the skills repo.

## Description


Matches the lighting of the LEDs to Mycroft's behavior.

LEDs are turned off by default and will turn once the wake word is spoken. They trace the direction of the user during input and will show a pulse animation when Mycroft answers.


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.16</sub>