### PR TITLE
Add picroft-mute-skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -232,3 +232,6 @@
 [submodule "homescreen"]
 	path = homescreen
 	url = https://github.com/MycroftAI/skill-homescreen
+[submodule "picroft-mute-skill"]
+	path = picroft-mute-skill
+	url = https://github.com/derekantrican/picroft-mute-skill


### PR DESCRIPTION

## Info

This PR adds the new skill, [picroft-mute-skill](https://github.com/derekantrican/picroft-mute-skill), to the skills repo.

## Description


Adds support for a mute button to picroft using the gpio pins. You can either say one of the mute phrases (such as "Mycroft, mute" or "Mycroft, stop listening") or push the button to toggle mute.

To configure this skill go [to the skill config](https://account.mycroft.ai/skills)

![](https://i.imgur.com/Nge0pfE.png)


<sub>Created with [mycroft-skills-kit](https://github.com/mycroftai/mycroft-skills-kit) v0.3.16</sub>